### PR TITLE
Update CheckoutTask.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/CheckoutTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/CheckoutTask.java
@@ -7,10 +7,12 @@ import hudson.remoting.VirtualChannel;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
+import java.util.Date;
 
 import org.jenkinsci.plugins.p4.client.ClientHelper;
 import org.jenkinsci.plugins.p4.client.ConnectionHelper;
@@ -129,12 +131,36 @@ public class CheckoutTask implements FileCallable<Boolean>, Serializable {
 			}
 			p4.log("Connected to client: " + client);
 
+			long lStartTime = new Date().getTime();
+			
+			
+			
+			
 			// Tidy the workspace before sync/build
 			p4.tidyWorkspace(populate);
-
+			p4.log("SCM Task: Prepare duration : " + (new Date().getTime() - lStartTime)/1000+" s");
+			
+			lStartTime = new Date().getTime();
+			
+			
+			try {
+				//Write the build change to a properties file so other tools can pick it up
+				String propFile=workspace.getAbsolutePath()+File.separator+"p4-plugin.properties";
+				PrintWriter printWriter = new PrintWriter(propFile);
+				printWriter.println ("buildChange="+buildChange);
+			    printWriter.close ();   
+			    p4.log("Created :"+propFile);
+			
+			} catch (IOException e) {
+			   
+			}
+			
+			
 			// Sync workspace to label, head or specified change
 			p4.syncFiles(buildChange, populate);
 
+			p4.log("SCM Task: Sync duration : " + (new Date().getTime() - lStartTime)/1000+" s");
+			
 			// Unshelve review if specified
 			if (status == CheckoutStatus.SHELVED) {
 				p4.unshelveFiles(review);


### PR DESCRIPTION
JENKINS-24741 : Expose duration of events.
Adding simple duration code generates:
SCM Task: restoring all missing and changed revisions.
... [list] = reconcile [-n, -e, -d, -f]
SCM Task: Prepare duration : 52 s
SCM Task: syncing files at change: 74227
... sync C:\Program Files (x86)\Jenkins\jobs\b2\workspace/...@74227
... force update false
... bypass have false
SCM Task: Sync duration : 0 s

JENKINS-25648 : P4_CHANGELIST variable
Adding a local properties file solves the problem better.
I can set my build name for example to
# ${BUILD_NUMBER}.${PROPFILE,file="p4-plugin.properties",property="buildChange"}

or use the env-inject plugin to use it later.

We could add other items i suppose
