### PR TITLE
Fixing loss of unshelved changes - Update ClientHelper.java [JENKINS-25724]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -551,6 +551,13 @@ public class ClientHelper extends ConnectionHelper {
 		String path = iclient.getRoot() + "/...";
 		files = FileSpecBuilder.makeFileSpecList(path);
 
+		// Remove opened files from have list.
+		RevertFilesOptions rOpts = new RevertFilesOptions();
+		rOpts.setNoUpdate(true);
+		log("... revert -k " + path);
+		List<IFileSpec> rvtMsg = iclient.revertFiles(files, rOpts);
+		validateFileSpecs(rvtMsg, "file(s) not opened on this client");
+
 		// Unshelve change for review
 		List<IFileSpec> shelveMsg;
 		log("... unshelve -f -s " + review);
@@ -570,12 +577,6 @@ public class ClientHelper extends ConnectionHelper {
 			}
 		}
 
-		// Remove opened files from have list.
-		RevertFilesOptions rOpts = new RevertFilesOptions();
-		rOpts.setNoUpdate(true);
-		log("... revert -k " + path);
-		List<IFileSpec> rvtMsg = iclient.revertFiles(files, rOpts);
-		validateFileSpecs(rvtMsg, "file(s) not opened on this client");
 		log("... duration: " + timer.toString());
 	}
 


### PR DESCRIPTION
Moving `revert -k` operation in unshelveFiles() to before the unshelving process. Without this, when `revert -k` is done after the unshelving process, the unshelved changes are lost. This results in the [review build option](https://github.com/jenkinsci/p4-plugin#review) to be unusable and also renders the [swarm jenkins integration](http://www.perforce.com/blog/140910/continuous-integration-new-perforce-server-plugin-jenkins) unusable. 

I am not a Java developer and don't have the resources to test / verify this change. I tried `mvn package`, but ran into build errors related from some other dependency. If this change is valid in theory and if you can help me build the package, I can test it. Our team is moving to use the new p4 plugin and this is one the critical features for us and one that will also help convince adoption of this plugin to other teams in our organization.

I guess this issue has already been reported : [JENKINS-25724](https://issues.jenkins-ci.org/browse/JENKINS-25724)

Can you please review this change @p4paul 