### PR TITLE
Fix JENKINS-28760: Set line endings explicitly for template workspaces

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/workspace/TemplateWorkspaceImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/workspace/TemplateWorkspaceImpl.java
@@ -76,6 +76,9 @@ public class TemplateWorkspaceImpl extends Workspace {
 		// Set owner (not set during create)
 		iclient.setOwnerName(user);
 
+		// set line endings explicitly (JENKINS-28760)
+		iclient.setLineEnd(itemplate.getLineEnd());
+
 		// Root required to switch view; must reload values in iclient.
 		iclient.setRoot(getRootPath());
 		iclient.update();


### PR DESCRIPTION
This fixes the issue for me both in instances of creating a new workspace from a template, and in updating a previously-created workspace from a template.