### PR TITLE
JENKINS-29943: Check for empty param values

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/CheckoutTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/CheckoutTask.java
@@ -142,12 +142,14 @@ public class CheckoutTask extends AbstractTask implements
 		String populateLabel = populate.getPin();
 		if (populateLabel != null && !populateLabel.isEmpty()) {
 			// Expand label with environment vars if one was defined
-			populateLabel = expand.format(populateLabel, false);
-			try {
-				// if build is a change-number passed as a label
-				build = Integer.parseInt(populateLabel);
-			} catch (NumberFormatException e) {
-				build = populateLabel;
+			String expandedPopulateLabel = expand.format(populateLabel, false);
+			if(!expandedPopulateLabel.isEmpty()) {
+				try {
+					// if build is a change-number passed as a label
+					build = Integer.parseInt(expandedPopulateLabel);
+				} catch (NumberFormatException e) {
+					build = expandedPopulateLabel;
+				}
 			}
 		}
 


### PR DESCRIPTION
Adding an isEmpty() check after expanding the value of the
populateLabel, since a parameter value may be empty.