### PR TITLE
[FIXED JENKINS-30163] P4TICKETS file credential doesn't work

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/credentials/TicketModeImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/credentials/TicketModeImpl.java
@@ -6,6 +6,8 @@ import hudson.model.Descriptor;
 
 import java.io.Serializable;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -49,11 +51,11 @@ public class TicketModeImpl extends AbstractDescribableImpl<TicketModeImpl>
 	}
 
 	public boolean isTicketValueSet() {
-		return getTicketValue() != null;
+		return !StringUtils.isEmpty(getTicketValue());
 	}
 
 	public boolean isTicketPathSet() {
-		return getTicketValue() == null;
+		return !StringUtils.isEmpty(getTicketPath());
 	}
 
 	@Extension


### PR DESCRIPTION
Using StringUtils.isEmpty() rather than null check to see if ticketValue
/ ticketPath are set since both values are explicitly marked non null.
Previously, ticketValue was empty, but isTicketValueSet() returned true
when the user intended to use a ticket file instead.