### PR TITLE
Make P4_TICKET usable on all hosts (i.e. slaves)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
@@ -32,6 +32,7 @@ import com.perforce.p4java.impl.mapbased.server.Server;
 import com.perforce.p4java.option.server.ChangelistOptions;
 import com.perforce.p4java.option.server.GetDepotFilesOptions;
 import com.perforce.p4java.option.server.GetFixesOptions;
+import com.perforce.p4java.option.server.LoginOptions;
 import com.perforce.p4java.server.CmdSpec;
 import com.perforce.p4java.server.IOptionsServer;
 import com.perforce.p4java.server.callback.ICommandCallback;
@@ -218,7 +219,7 @@ public class ConnectionHelper {
 		case PASSWORD:
 			if (!isLogin()) {
 				String pass = authorisationConfig.getPassword();
-				connection.login(pass);
+				connection.login(pass, new LoginOptions(/* allHosts = */ true));
 			}
 			break;
 


### PR DESCRIPTION
This is necessary when using automated Perforce merge scripts in build jobs.

When using a lot of streams automated merges between those become a necessity. This however, requires the build script to have access to do a `p4 integrate` and a `p4 submit` afterwards.

This PR makes it possible to use `P4_TICKET` (with the `-P` option) on nodes that are not the master, i.e. build slaves.