### PR TITLE
[JENKINS-35210] Fix for SECURITY-170

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/review/SafeParametersAction.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/review/SafeParametersAction.java
@@ -1,0 +1,74 @@
+package org.jenkinsci.plugins.p4.review;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+@Restricted(NoExternalUse.class)
+public class SafeParametersAction extends ParametersAction {
+
+	private List<ParameterValue> internalParameters;
+
+	public SafeParametersAction(@NonNull List<ParameterValue> params, @NonNull List<ParameterValue> internalParameters) {
+		// Apply security to regular parameters
+		super(params);
+		this.internalParameters = internalParameters;
+	}
+
+	@Override
+	public List<ParameterValue> getParameters() {
+		List<ParameterValue> params = new ArrayList<ParameterValue>();
+		List<ParameterValue> p = super.getParameters();
+		params.addAll(p);
+		params.addAll(internalParameters);
+		return Collections.unmodifiableList(params);
+	}
+
+	@Override
+	public ParameterValue getParameter(String name) {
+		ParameterValue param = super.getParameter(name);
+		if (param != null) {
+			return param;
+		}
+		for (ParameterValue p : internalParameters) {
+			if (p == null) continue;
+			if (p.getName().equals(name))
+				return p;
+		}
+		return null;
+	}
+
+	List<ParameterValue> getInternalParameters() {
+		return Collections.unmodifiableList(internalParameters);
+	}
+
+	@Extension
+	public static final class SafeParametersActionEnvironmentContributor extends EnvironmentContributor {
+
+		@Override
+		public void buildEnvironmentFor(Run r, EnvVars envs, TaskListener listener)
+				throws IOException, InterruptedException {
+			SafeParametersAction action = r.getAction(SafeParametersAction.class);
+			if (action != null) {
+				for (ParameterValue pv : action.getInternalParameters()) {
+					envs.put(pv.getName(), String.valueOf(pv.getValue()));
+				}
+			}
+		}
+		
+	}
+
+}

--- a/src/test/java/org/jenkinsci/plugins/p4/client/ConnectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/ConnectionTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -26,6 +27,7 @@ import org.jenkinsci.plugins.p4.filters.FilterPerChangeImpl;
 import org.jenkinsci.plugins.p4.populate.AutoCleanImpl;
 import org.jenkinsci.plugins.p4.populate.Populate;
 import org.jenkinsci.plugins.p4.review.ReviewProp;
+import org.jenkinsci.plugins.p4.review.SafeParametersAction;
 import org.jenkinsci.plugins.p4.workspace.ManualWorkspaceImpl;
 import org.jenkinsci.plugins.p4.workspace.StaticWorkspaceImpl;
 import org.jenkinsci.plugins.p4.workspace.StreamWorkspaceImpl;
@@ -60,7 +62,6 @@ import hudson.model.Descriptor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParameterValue;
-import hudson.model.ParametersAction;
 import hudson.model.Result;
 import hudson.model.StringParameterValue;
 import hudson.model.Cause.UserIdCause;
@@ -232,7 +233,7 @@ public class ConnectionTest {
 		List<ParameterValue> list = new ArrayList<ParameterValue>();
 		list.add(new StringParameterValue(ReviewProp.STATUS.toString(), "committed"));
 		list.add(new StringParameterValue(ReviewProp.CHANGE.toString(), "9"));
-		Action actions = new ParametersAction(list);
+		Action actions = new SafeParametersAction(new ArrayList<ParameterValue>(), list);
 
 		FreeStyleBuild build;
 		UserIdCause cause = new Cause.UserIdCause();
@@ -287,7 +288,7 @@ public class ConnectionTest {
 		list.add(new StringParameterValue(ReviewProp.STATUS.toString(), "committed"));
 		list.add(new StringParameterValue(ReviewProp.LABEL.toString(), "auto15"));
 		list.add(new StringParameterValue(ReviewProp.PASS.toString(), HTTP_URL + "/pass"));
-		Action actions = new ParametersAction(list);
+		Action actions = new SafeParametersAction(new ArrayList<ParameterValue>(), list);
 
 		FreeStyleBuild build;
 		UserIdCause cause = new Cause.UserIdCause();
@@ -344,7 +345,7 @@ public class ConnectionTest {
 		list.add(new StringParameterValue(ReviewProp.STATUS.toString(), "shelved"));
 		list.add(new StringParameterValue(ReviewProp.REVIEW.toString(), "19"));
 		list.add(new StringParameterValue(ReviewProp.PASS.toString(), HTTP_URL + "/pass"));
-		Action actions = new ParametersAction(list);
+		Action actions = new SafeParametersAction(new ArrayList<ParameterValue>(), list);
 
 		FreeStyleBuild build;
 		UserIdCause cause = new Cause.UserIdCause();
@@ -541,7 +542,7 @@ public class ConnectionTest {
 		List<ParameterValue> list = new ArrayList<ParameterValue>();
 		list.add(new StringParameterValue(ReviewProp.STATUS.toString(), "shelved"));
 		list.add(new StringParameterValue(ReviewProp.REVIEW.toString(), "19"));
-		Action actions = new ParametersAction(list);
+		Action actions = new SafeParametersAction(new ArrayList<ParameterValue>(), list);
 
 		FreeStyleBuild build;
 		UserIdCause cause = new Cause.UserIdCause();
@@ -578,7 +579,7 @@ public class ConnectionTest {
 		List<ParameterValue> list = new ArrayList<ParameterValue>();
 		list.add(new StringParameterValue(ReviewProp.STATUS.toString(), "submitted"));
 		list.add(new StringParameterValue(ReviewProp.CHANGE.toString(), "3"));
-		Action actions = new ParametersAction(list);
+		Action actions = new SafeParametersAction(new ArrayList<ParameterValue>(), list);
 
 		FreeStyleBuild build;
 		UserIdCause cause = new Cause.UserIdCause();
@@ -617,7 +618,7 @@ public class ConnectionTest {
 		List<ParameterValue> list = new ArrayList<ParameterValue>();
 		list.add(new StringParameterValue(ReviewProp.STATUS.toString(), "submitted"));
 		list.add(new StringParameterValue(ReviewProp.CHANGE.toString(), "3"));
-		Action actions = new ParametersAction(list);
+		Action actions = new SafeParametersAction(new ArrayList<ParameterValue>(), list);
 
 		FreeStyleBuild build;
 		UserIdCause cause = new Cause.UserIdCause();


### PR DESCRIPTION
This PR fixes parameters visibility after SECURITY-170 inclusion in core (1.651.2 or 2.3+).
It also fixes tests failing under `mvn test -Djenkins.version=1.651.2` (due to the same issue).

@reviewbybees 