### PR TITLE
Convert merge options for unshelve to ListBoxModel Option (from basic jelly) 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
@@ -20,6 +20,8 @@ import hudson.scm.SCM;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
+import hudson.util.ListBoxModel;
+import hudson.util.ListBoxModel.Option;
 import jenkins.model.Jenkins;
 
 public class UnshelveBuilder extends Builder {
@@ -102,6 +104,7 @@ public class UnshelveBuilder extends Builder {
 		}
 		return null;
 	}
+        
 
 	@Extension
 	public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
@@ -116,5 +119,14 @@ public class UnshelveBuilder extends Builder {
 		public String getDisplayName() {
 			return "Perforce: Unshelve";
 		}
+                
+                public ListBoxModel doFillResolveItems() {
+                    return new ListBoxModel(new Option("Resolve: None", "none"),
+                                            new Option("Resolve: Safe (-as)", "as"),
+                                            new Option("Resolve: Merge (-am)", "am"),
+                                            new Option("Resolve: Force Merge (-af)", "af"),
+                                            new Option("Resolve: Yours (-ay) -- keep your edits", "ay"),
+                                            new Option("Resolve: Merge (Resolve: Theirs (-at) -- keep shelf content)", "at"));       
+                }
 	}
 }

--- a/src/main/resources/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder/config.jelly
@@ -4,15 +4,9 @@
 	<f:entry title="Unshelve Changelist" field="shelf">
 		<f:textbox />
 	</f:entry>
-		  
-	<f:entry name="resolve" title="Resolve Options" field="resolve">
-		<select name="resolve">
-			<option value="none">Resolve: None</option>
-			<option value="as">Resolve: Safe (-as)</option>
-			<option value="am">Resolve: Merge (-am)</option>
-			<option value="ay">Resolve: Yours (-ay) -- keep your edits</option>
-			<option value="at">Resolve: Theirs (-at) -- keep shelf content</option>
-		</select>
-	</f:entry>
+
+        <f:entry field="resolve" title="Resolve Options">
+           <f:select />
+        </f:entry>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/p4/workflow/P4UnshelveStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/workflow/P4UnshelveStep/config.jelly
@@ -5,15 +5,8 @@
 	<f:entry title="Unshelve Changelist" field="shelf">
 		<f:textbox />
 	</f:entry>
-		  
-	<f:entry name="resolve" title="Resolve Options" field="resolve">
-		<select name="resolve">
-			<option value="none">Resolve: None</option>
-			<option value="as">Resolve: Safe (-as)</option>
-			<option value="af">Resolve: Force Merge (-af)</option>
-			<option value="ay">Resolve: Yours (-ay) -- keep your edits</option>
-			<option value="at">Resolve: Theirs (-at) -- keep shelf content</option>
-		</select>
-	</f:entry>
+        <f:entry field="resolve" title="Resolve Options">
+           <f:select />
+        </f:entry>
 	
 </j:jelly>


### PR DESCRIPTION
switch dropdown list for merge options from basic jelly select option to ListBoxModel Option configured in Descriptor, this fixes issue with dropdown list not being set with selected value after saving and then entering configuration again