### PR TITLE
Workspace's root path overwritten to "null" when enabling polling in Pipeline job

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
@@ -303,6 +303,11 @@ public class PerforceScm extends SCM {
 		envVars.put("NODE_NAME", envVars.get("NODE_NAME", nodeName));
 
 		Workspace ws = (Workspace) workspace.clone();
+		String root = buildWorkspace.getRemote();
+		if (root.contains("@")) {
+			root = root.replace("@", "%40");
+		}
+		ws.setRootPath(root);
 		ws.setExpand(envVars);
 
 		// don't call setRootPath() here, polling is often on the master


### PR DESCRIPTION
We created a 'Freestyle project' (which restricted on remote node) and choose 'Perforce Software'  with 'Template (view generated for each node)', and then enable 'Poll SCM'. it'll set the workspace's 'Root' to 'null'.

Another thing when we used "p4sync" step with template mode to sync code in our Pipeline job and enabled "Poll SCM" in Pipeline job and at the same time.  When polling, it will overwrite the workspace's "Root" with "null" too. And from the debugging, it seems polling on 'master'.
<-pollWorkspace:306, PerforceScm (org.jenkinsci.plugins.p4), PerforceScm.java
<- compareRemoteRevisionWith(Job, Launcher, FilePath, TaskListener, SCMRevisionState):281, PerforceScm (org.jenkinsci.plugins.p4), PerforceScm.java
<-poll(TaskListener):603, WorkflowJob (org.jenkinsci.plugins.workflow.job), WorkflowJob.java
<-runPolling():528, SCMTrigger$Runner (hudson.triggers), SCMTrigger.java
<-run():574, SCMTrigger$Runner (hudson.triggers), SCMTrigger.java