### PR TITLE
Not throw AbortException when unknown errors (except for those ignoring ones ) occurred during P4 task post-validation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/Validate.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/Validate.java
@@ -59,9 +59,9 @@ public class Validate {
 						msg = "P4JAVA: " + msg;
 						log(msg);
 						logger.warning(msg);
-						if (status == FileSpecOpStatus.ERROR || status == FileSpecOpStatus.CLIENT_ERROR) {
-							abort = true;
-						}
+					}
+					if (status == FileSpecOpStatus.ERROR || status == FileSpecOpStatus.CLIENT_ERROR) {
+						abort = true;
 					}
 					success = false;
 				}

--- a/src/main/java/org/jenkinsci/plugins/p4/console/P4ConsoleAnnotator.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/console/P4ConsoleAnnotator.java
@@ -34,6 +34,22 @@ public class P4ConsoleAnnotator extends ConsoleAnnotator<Object> {
 		text.addMarkup(COMMAND.length(), head);
 
 		StringBuffer sb = new StringBuffer();
+
+		sb.append("<script>\n");
+		sb.append("function toggle(showHideDiv, switchTextDiv) {\n");
+		sb.append("\tvar tog = document.getElementById(showHideDiv);\n");
+		sb.append("\tvar text = document.getElementById(switchTextDiv);\n");
+		sb.append("\tif(tog.style.display == \"block\") {\n");
+		sb.append("    \ttog.style.display = \"none\";\n");
+		sb.append("\t\ttext.innerHTML = \"+\";\n");
+		sb.append("  \t}\n");
+		sb.append("\telse {\n");
+		sb.append("\t\ttog.style.display = \"block\";\n");
+		sb.append("\t\ttext.innerHTML = \"-\";\n");
+		sb.append("\t}\n");
+		sb.append("}\n");
+		sb.append("</script>");
+
 		sb.append(" <a class=\"linkDiv\" id=\"");
 		sb.append("p4title" + id);
 		sb.append("\" href=\"javascript:toggle('");

--- a/src/main/java/org/jenkinsci/plugins/p4/console/P4ConsoleAnnotator.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/console/P4ConsoleAnnotator.java
@@ -34,22 +34,6 @@ public class P4ConsoleAnnotator extends ConsoleAnnotator<Object> {
 		text.addMarkup(COMMAND.length(), head);
 
 		StringBuffer sb = new StringBuffer();
-
-		sb.append("<script>\n");
-		sb.append("function toggle(showHideDiv, switchTextDiv) {\n");
-		sb.append("\tvar tog = document.getElementById(showHideDiv);\n");
-		sb.append("\tvar text = document.getElementById(switchTextDiv);\n");
-		sb.append("\tif(tog.style.display == \"block\") {\n");
-		sb.append("    \ttog.style.display = \"none\";\n");
-		sb.append("\t\ttext.innerHTML = \"+\";\n");
-		sb.append("  \t}\n");
-		sb.append("\telse {\n");
-		sb.append("\t\ttog.style.display = \"block\";\n");
-		sb.append("\t\ttext.innerHTML = \"-\";\n");
-		sb.append("\t}\n");
-		sb.append("}\n");
-		sb.append("</script>");
-
 		sb.append(" <a class=\"linkDiv\" id=\"");
 		sb.append("p4title" + id);
 		sb.append("\" href=\"javascript:toggle('");


### PR DESCRIPTION
We found that the post validation process didn't throw exception when some unknown errors (except for those ignoring ones ) occurred during P4 task.