### PR TITLE
[WIP] Support native p4 for reconciles

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -256,6 +256,59 @@ public class ClientHelper extends ConnectionHelper {
 		}
 	}
 
+	private int CheckNativeUseReconcile(String path, List<String> reconcileOpts, ParallelSync parallel) {
+		try {
+			String p4 = parallel.getPath();
+
+			List<String> command = new ArrayList<String>();
+			String p4port = p4credential.getP4port();
+			p4port = (p4credential.isSsl()) ? "ssl:" + p4port : p4port;
+			command.add(p4);
+			command.add("-c" + iclient.getName());
+			command.add("-p" + p4port);
+			command.add("-u" + p4credential.getUsername());
+
+			command.add("reconcile");
+			command.addAll(reconcileOpts);
+			command.add(path);
+
+			ProcessBuilder builder = new ProcessBuilder(command);
+			final Process process = builder.start();
+			InputStream inputStream = process.getInputStream();
+			InputStream errorStream = process.getErrorStream();
+
+			BufferedReader inputStreamReader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
+			BufferedReader errorStreamReader = new BufferedReader(new InputStreamReader(errorStream, "UTF-8"));
+
+			// Log commands
+			log("(p4):cmd:... " + StringUtils.join(command, " "));
+			log("");
+
+			String line;
+			while ((line = inputStreamReader.readLine()) != null) {
+				log(line);
+			}
+			while ((line = errorStreamReader.readLine()) != null) {
+				log(line);
+			}
+			int exitCode = process.waitFor();
+
+			inputStreamReader.close();
+			errorStreamReader.close();
+
+			log("exitCode=" + Integer.toString(exitCode));
+			log("(p4):stop:0");
+			return exitCode;
+		} catch (UnsupportedEncodingException e) {
+			log(e.getMessage());
+		} catch (IOException e) {
+			log(e.getMessage());
+		} catch (InterruptedException e) {
+			log(e.getMessage());
+		}
+		return 1;
+	}
+
 	private int CheckNativeUse(String revisions, SyncOptions syncOpts, ParallelSync parallel) {
 
 		try {
@@ -470,6 +523,17 @@ public class ClientHelper extends ConnectionHelper {
 			}
 		}
 
+		ParallelSync parallel = populate.getParallel();
+		if (parallel != null && parallel.isEnable()) {
+			TimeTask timer = new TimeTask();
+			log("P4 Task Native: cleaning workspace to match have list.");
+			int exitCode = CheckNativeUseReconcile(path, list, parallel);
+			log("duration: " + timer.toString() + "\n");
+			if (exitCode == 0) {
+				return;
+			}
+		}
+		//fallback
 		TimeTask timer = new TimeTask();
 		log("P4 Task: cleaning workspace to match have list.");
 

--- a/src/main/java/org/jenkinsci/plugins/p4/review/ReviewAction.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/review/ReviewAction.java
@@ -100,8 +100,9 @@ public class ReviewAction<T extends Job<?, ?> & ParameterizedJob> implements Act
 		TimeDuration delay = new TimeDuration(project.getQuietPeriod());
 		CauseAction cause = new CauseAction(new Cause.UserIdCause());
 
-		List<ParameterValue> internalParams = extractAndRemoveInternalParameters(values);
-		ParametersAction params = new SafeParametersAction(values, internalParams);
+		//List<ParameterValue> internalParams = extractAndRemoveInternalParameters(values);
+		//ParametersAction params = new SafeParametersAction(values, internalParams);
+		ParametersAction params = new ParametersAction(values);
 
 		Jenkins j = Jenkins.getInstance();
 		if (j != null) {


### PR DESCRIPTION
Hi there, this is just a WIP I'm running with on our build farm. I basically highjack the enable parallel sync option and support running native reconcile. The reason I did this is to properly support the modtime reconcile. On our slower build machines, it went **from 19 minutes to 14 seconds** . While I'd like p4java to properly support modtime reconcile, I suspect like the parallel sync, that is not a high priority. I'd appreciate your feedback on how to improve this change for possible merge. 

Important caveats. If you sync using the p4java layer, this will not use the modtime path when reconciling. You must sync using the p4 command line ie. parallelsync even if it's set to 0 threads to simulate non parallel behavior. For whatever reason the server won't choose the fast modtime sync when syncing using p4java.

The fastest way I found to get this working is to increment/modify your workspaces name once you've made the setting changes, ie. enabled parallelsync to force resync.

For anyone reading this who may not understand what syncing and reconciling have to do with each other, it appears as if the decision to use the modtime when reconciling is a server decision ultimately, and depending on how you sync/version of p4, the reconcile feature may or may not work as you expect.

Apologies for the long message.
