### PR TITLE
Make P4AddressResolver discoverable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/email/P4AddressResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/email/P4AddressResolver.java
@@ -1,10 +1,12 @@
 package org.jenkinsci.plugins.p4.email;
 
+import hudson.Extension;
 import hudson.model.User;
 import hudson.tasks.MailAddressResolver;
 
 import java.util.logging.Logger;
 
+@Extension
 public class P4AddressResolver extends MailAddressResolver {
 
 	private static Logger logger = Logger.getLogger(P4AddressResolver.class


### PR DESCRIPTION
Partially related to https://issues.jenkins-ci.org/browse/JENKINS-28421

The P4AddressResolver was not ending up in the list of resolvers in the mailer-plugin.