### PR TITLE
Use latest change for all builds when polling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
@@ -277,14 +277,27 @@ public class PerforceScm extends SCM {
 		}
 
 		// get last action, if no previous action then build now.
-		TagAction action = lastRun.getAction(TagAction.class);
-		if (action == null) {
+		List<TagAction> actions = lastRun.getActions(TagAction.class);
+		if (actions.isEmpty()) {
 			listener.getLogger().println("No previous build found; building...");
 			return PollingResult.BUILD_NOW;
 		}
 
-		// found previous build, set last change.
-		P4Revision last = action.getBuildChange();
+		// found previous build, set last change to the first action found.
+		P4Revision last = actions.get(0).getBuildChange();
+
+                // Find the change with the highest change number, use this for the
+                // poll. This isn't accurate if multiple workspaces are polled
+                // and are disjoint, but is accurate if the workspaces are subsets
+                // of each other.
+                for (TagAction action : actions) {
+                        if (action.getBuildChange().compareTo(last) > 0) {
+                                last = action.getBuildChange();
+                        }
+                }
+
+                listener.getLogger().println("Found last change " + last.toString() +
+                                             " in previous build");
 
 		if (job instanceof MatrixProject) {
 			if (isBuildParent(job)) {


### PR DESCRIPTION
This fixes the case where multiple checkouts are present
in a pipeline for example and they are nested. Then using
the latest change instead of the first (as done previously)
ensures that continous builds are not triggered. This
does not fix the case where the checkouts are completely
disjoint.

JENKINS-40048