### PR TITLE
added new method to run with a string list of arguments

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/groovy/P4Groovy.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/groovy/P4Groovy.java
@@ -51,6 +51,14 @@ public class P4Groovy implements Serializable {
 		return map;
 	}
 
+	public Map<String, Object>[] runWithArgArr(String cmd, List<String> args) throws P4JavaException {
+		String[] array = args.toArray(new String[0]);
+		IOptionsServer p4 = getConnection();
+		Map<String, Object>[] map = p4.execMapCmd(cmd, array, null);
+		p4.disconnect();
+		return map;
+	}
+
 	public Map<String, Object>[] save(String type, Map<String, Object> spec) throws P4JavaException {
 		String[] array = { "-i" };
 		IOptionsServer p4 = getConnection();


### PR DESCRIPTION
We'd like to make a p4 query like this:
p4 changes //MyTree/main/...@2016/12/05:16:00:00,@184805

but in the p4Groovy::run function, the arg string is split by commas -- which breaks these arguments.

This new function allows you to specify each argument in a list, thus avoiding the issue..