### PR TITLE
Strip the trailing slash in the depot path so that p4sync step doesn'…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/workflow/P4Step.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/workflow/P4Step.java
@@ -125,9 +125,13 @@ public class P4Step extends SCMStep {
 			else if (notNull(template))
 				workspace = new TemplateWorkspaceImpl(charset, false, template, format);
 			else if (notNull(depotPath)) {
-				if (depotPath.endsWith("/"))
-					depotPath = depotPath.substring(0, depotPath.length()-1);
-				String view = depotPath + "/..." + " " + "//" + format + "/...";
+				if(depotPath.endsWith("/")) {
+					depotPath = depotPath + "...";
+				}
+				if(!depotPath.endsWith("/...")) {
+					depotPath = depotPath + "/...";
+				}
+				String view = depotPath + " " + "//" + format + "/...";
 				WorkspaceSpec spec = new WorkspaceSpec(false, false, false, false, false, false, null, "local", view);
 
 				workspace = new ManualWorkspaceImpl(charset, false, format, spec);

--- a/src/main/java/org/jenkinsci/plugins/p4/workflow/P4Step.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/workflow/P4Step.java
@@ -125,6 +125,8 @@ public class P4Step extends SCMStep {
 			else if (notNull(template))
 				workspace = new TemplateWorkspaceImpl(charset, false, template, format);
 			else if (notNull(depotPath)) {
+				if (depotPath.endsWith("/"))
+					depotPath = depotPath.substring(0, depotPath.length()-1);
 				String view = depotPath + "/..." + " " + "//" + format + "/...";
 				WorkspaceSpec spec = new WorkspaceSpec(false, false, false, false, false, false, null, "local", view);
 


### PR DESCRIPTION
Strip the trailing slash in the depot path so that p4sync step doesn't fail.

Ran into this a couple of times while using the plugin, so I thought I'd submit a change.