### PR TITLE
Removed some spam from the Jenkins log

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/email/P4AddressResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/email/P4AddressResolver.java
@@ -8,17 +8,12 @@ import java.util.logging.Logger;
 
 @Extension
 public class P4AddressResolver extends MailAddressResolver {
-
-	private static Logger logger = Logger.getLogger(P4AddressResolver.class
-			.getName());
-
 	@Override
 	public String findMailAddressFor(User user) {
 		P4UserProperty prop = user.getProperty(P4UserProperty.class);
 		if (prop != null) {
 			String id = user.getId();
 			String email = prop.getEmail();
-			logger.info("MailAddressResolver: " + id + ":" + email);
 			return email;
 		}
 		return null;


### PR DESCRIPTION
This method is called very frequently when doing a checkout, and it fills the Jenkins log with a lot of spam that isn't very helpful.