### PR TITLE
Implement a FlushOnly sync for "Populate Options"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -73,6 +73,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.jenkinsci.plugins.p4.populate.FlushOnlyImpl;
 
 public class ClientHelper extends ConnectionHelper {
 
@@ -194,7 +195,7 @@ public class ClientHelper extends ConnectionHelper {
 				}
 			}
 		} else {
-			log("P4 Task: syncing files at change: " + buildChange);
+			log("P4 Task: syncing files at changes: " + buildChange);
 		}
 
 		// Sync changes/labels
@@ -204,7 +205,7 @@ public class ClientHelper extends ConnectionHelper {
 			String revisions = path + "@" + buildChange;
 
 			// Sync files
-			if (populate instanceof CheckOnlyImpl) {
+			if (populate instanceof CheckOnlyImpl || populate instanceof FlushOnlyImpl) {
 				syncHaveList(revisions, populate);
 			} else {
 				syncFiles(revisions, populate);
@@ -228,7 +229,7 @@ public class ClientHelper extends ConnectionHelper {
 	private boolean syncHaveList(String revisions, Populate populate) throws Exception {
 		// Preview (sync -k)
 		SyncOptions syncOpts = new SyncOptions();
-		syncOpts.setClientBypass(true);
+		syncOpts.setClientBypass(populate.isHave());
 		syncOpts.setQuiet(populate.isQuiet());
 
 		List<IFileSpec> files = FileSpecBuilder.makeFileSpecList(revisions);

--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -195,7 +195,7 @@ public class ClientHelper extends ConnectionHelper {
 				}
 			}
 		} else {
-			log("P4 Task: syncing files at changes: " + buildChange);
+			log("P4 Task: syncing files at change: " + buildChange);
 		}
 
 		// Sync changes/labels

--- a/src/main/java/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.p4.populate;
+
+import hudson.Extension;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class FlushOnlyImpl extends Populate {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * No sync, check change only
+	 *
+	 * @param have    populate have list
+	 * @param force   force sync
+	 * @param modtime use MODTIME for reconcile
+	 * @param quiet   Perforce quiet option
+	 * @param pin     Change or label to pin the sync
+	 */
+	@DataBoundConstructor
+	public FlushOnlyImpl(boolean have, boolean force, boolean modtime, boolean quiet,
+	                     String pin) {
+		super(true, false, false, quiet, null, null); 
+	}
+
+	@Extension
+	public static final class DescriptorImpl extends PopulateDescriptor {
+
+		@Override
+		public String getDisplayName() {
+                    return "Flush workspace";
+		}
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl.java
@@ -18,9 +18,8 @@ public class FlushOnlyImpl extends Populate {
 	 * @param pin     Change or label to pin the sync
 	 */
 	@DataBoundConstructor
-	public FlushOnlyImpl(boolean have, boolean force, boolean modtime, boolean quiet,
-	                     String pin) {
-		super(true, false, false, quiet, pin, null); 
+	public FlushOnlyImpl(boolean have, boolean force, boolean modtime, boolean quiet, String pin) {
+		super(true, false, false, quiet, pin, null);
 	}
 
 	@Extension
@@ -28,7 +27,7 @@ public class FlushOnlyImpl extends Populate {
 
 		@Override
 		public String getDisplayName() {
-                    return "Flush workspace";
+			return "Flush workspace";
 		}
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl.java
@@ -20,7 +20,7 @@ public class FlushOnlyImpl extends Populate {
 	@DataBoundConstructor
 	public FlushOnlyImpl(boolean have, boolean force, boolean modtime, boolean quiet,
 	                     String pin) {
-		super(true, false, false, quiet, null, null); 
+		super(true, false, false, quiet, pin, null); 
 	}
 
 	@Extension

--- a/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	
+	<f:entry field="quiet">
+		<f:checkbox title="${%QUIET Perforce messages}" default="true"/>
+	</f:entry>
+	
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/config.jelly
@@ -1,11 +1,11 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-	
+
 	<f:entry field="quiet">
 		<f:checkbox title="${%QUIET Perforce messages}" default="true"/>
 	</f:entry>
-	
-        <f:entry field="pin">
+
+	<f:entry field="pin">
 		<table border="0" width="100%">
 			<tr>
 				<td nowrap="true">Pin build at Perforce Label</td>

--- a/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/config.jelly
@@ -5,4 +5,12 @@
 		<f:checkbox title="${%QUIET Perforce messages}" default="true"/>
 	</f:entry>
 	
+        <f:entry field="pin">
+		<table border="0" width="100%">
+			<tr>
+				<td nowrap="true">Pin build at Perforce Label</td>
+				<td width="100%"><f:textbox/></td>
+			</tr>
+		</table>
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/help-pin.html
+++ b/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/help-pin.html
@@ -1,0 +1,9 @@
+<div>
+	<b>Pinning a build at Perforce Label</b>
+	<p>When a build is triggered by Polling, Build Now or an external
+		Action, the workspace will flush only to the specified label or changelist number. Any other
+		specified change or label will be ignored.</p>
+	<p>Supports variable expansion e.g. ${VAR}.  If 'now' is used, or a 
+		variable that expands to 'now', then the latest change is used 
+		(within the scope of the workspace view).</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/help-pin.html
+++ b/src/main/resources/org/jenkinsci/plugins/p4/populate/FlushOnlyImpl/help-pin.html
@@ -3,7 +3,7 @@
 	<p>When a build is triggered by Polling, Build Now or an external
 		Action, the workspace will flush only to the specified label or changelist number. Any other
 		specified change or label will be ignored.</p>
-	<p>Supports variable expansion e.g. ${VAR}.  If 'now' is used, or a 
-		variable that expands to 'now', then the latest change is used 
+	<p>Supports variable expansion e.g. ${VAR}.  If 'now' is used, or a
+		variable that expands to 'now', then the latest change is used
 		(within the scope of the workspace view).</p>
 </div>


### PR DESCRIPTION
This sync uses the `-k` flag in perforce to be able to use an already
existing sync on disk with a newly created clientspec.