### PR TITLE
Limit output from describe.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeEntry.java
@@ -106,7 +106,7 @@ public class P4ChangeEntry extends ChangeLogSet.Entry {
 			files = p4.getShelvedFiles(changeId);
 			shelved = true;
 		} else {
-			files = p4.getChangeFiles(changeId);
+			files = p4.getChangeFiles(changeId, fileCountLimit + 1);
 			shelved = false;
 		}
 		if (files != null && files.size() > fileCountLimit) {

--- a/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
@@ -62,6 +62,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.perforce.p4java.common.base.ObjectUtils.nonNull;
+import static com.perforce.p4java.server.CmdSpec.DESCRIBE;
 
 public class ConnectionHelper implements AutoCloseable {
 
@@ -275,7 +276,7 @@ public class ConnectionHelper implements AutoCloseable {
 
 			case TICKETPATH:
 				String path = authorisationConfig.getTicketPath();
-				if(path == null || path.isEmpty()) {
+				if (path == null || path.isEmpty()) {
 					path = connection.getTicketsFilePath();
 				}
 				connection.setTicketsFilePath(path);
@@ -548,9 +549,11 @@ public class ConnectionHelper implements AutoCloseable {
 
 	// Use a describe for files to avoid MAXSCANROW limits.
 	// (backed-out part of change 16390)
-	public List<IFileSpec> getChangeFiles(int id) throws Exception {
-		List<IFileSpec> files = connection.getChangelistFiles(id);
-		return files;
+	public List<IFileSpec> getChangeFiles(int id, int limit) throws Exception {
+		List<Map<String, Object>> resultMaps = connection.execMapCmdList(DESCRIBE,
+				new String[]{"-s", "-m" + limit, String.valueOf(id)}, null);
+
+		return ResultMapParser.parseCommandResultMapAsFileSpecs(id, connection, resultMaps);
 	}
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
@@ -62,7 +62,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.perforce.p4java.common.base.ObjectUtils.nonNull;
-import static com.perforce.p4java.server.CmdSpec.DESCRIBE;
 
 public class ConnectionHelper implements AutoCloseable {
 
@@ -550,10 +549,8 @@ public class ConnectionHelper implements AutoCloseable {
 	// Use a describe for files to avoid MAXSCANROW limits.
 	// (backed-out part of change 16390)
 	public List<IFileSpec> getChangeFiles(int id, int limit) throws Exception {
-		List<Map<String, Object>> resultMaps = connection.execMapCmdList(DESCRIBE,
-				new String[]{"-s", "-m" + limit, String.valueOf(id)}, null);
-
-		return ResultMapParser.parseCommandResultMapAsFileSpecs(id, connection, resultMaps);
+		List<IFileSpec> files = connection.getChangelistFiles(id, limit);
+		return files;
 	}
 
 	/**


### PR DESCRIPTION
P4Java has not limit support for getChangelistFiles; this is a
temporary workaround using execMap and the -m flag.