### PR TITLE
P4Unshelve build step can now be skipped successfully if the changelist ID is not set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ vagrant/
 .p4ignore
 
 docs/ppt/
+
+tmp-JenkinsfileTest-p4root/

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.7.7-SNAPSHOT-FGOL</version>
+  <version>1.7.6-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -33,11 +33,6 @@
       <name>Paul Allen</name>
       <email>pallen@perforce.com</email>
     </developer>
-    <developer>
-	  <id>mihailogazda</id>
-	  <name>Bojan Cup </name>
-	  <email>bojan.cup@ubisoft.com</email>
-	</developer>
   </developers>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT-FGOL</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -33,6 +33,11 @@
       <name>Paul Allen</name>
       <email>pallen@perforce.com</email>
     </developer>
+    <developer>
+	  <id>mihailogazda</id>
+	  <name>Bojan Cup </name>
+	  <email>bojan.cup@ubisoft.com</email>
+	</developer>
   </developers>
 
   <repositories>

--- a/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
@@ -39,6 +39,11 @@ public class UnshelveBuilder extends Builder {
 		this.tidy = tidy;
 		this.ignoreEmpty = ignoreEmpty;
 	}
+	
+	@Deprecated
+	public UnshelveBuilder(String shelf, String resolve, boolean tidy) {
+   		this(shelf, resolve, tidy, false);
+	}
 
 	@Deprecated
 	public UnshelveBuilder(String shelf, String resolve) {

--- a/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
@@ -28,19 +28,21 @@ public class UnshelveBuilder extends Builder {
 	private final String shelf;
 	private final String resolve;
 	private final boolean tidy;
+	private final boolean ignoreEmpty;
 
 	private static Logger logger = Logger.getLogger(UnshelveBuilder.class.getName());
 
 	@DataBoundConstructor
-	public UnshelveBuilder(String shelf, String resolve, boolean tidy) {
+	public UnshelveBuilder(String shelf, String resolve, boolean tidy, boolean ignoreEmpty) {
 		this.shelf = shelf;
 		this.resolve = resolve;
 		this.tidy = tidy;
+		this.ignoreEmpty = ignoreEmpty;
 	}
 
 	@Deprecated
 	public UnshelveBuilder(String shelf, String resolve) {
-		this(shelf, resolve, false);
+		this(shelf, resolve, false, false);
 	}
 
 	public BuildStepMonitor getRequiredMonitorService() {
@@ -57,6 +59,10 @@ public class UnshelveBuilder extends Builder {
 
 	public boolean isTidy() {
 		return tidy;
+	}
+	
+	public boolean isIgnoreEmpty(){
+		return ignoreEmpty;
 	}
 
 	@Override
@@ -99,8 +105,8 @@ public class UnshelveBuilder extends Builder {
 		// Expand shelf ${VAR} as needed and set as LABEL
 		String id = ws.getExpand().format(shelf, false);
 		
-		//	GOD BLESS FGOL AND HACKY CODE!
-		if (id == null || id.isEmpty())
+		//	If settings are set to do nothing if changelist is empty just return true.
+		if (ignoreEmpty && (id == null || id.isEmpty()))
 		{
 			logger.warning("Shelf list ID is empty or null, we will be skipping this task.");
 			return true;

--- a/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
@@ -46,6 +46,11 @@ public class UnshelveBuilder extends Builder {
 	}
 
 	@Deprecated
+	public UnshelveBuilder(String shelf, String resolve, boolean tidy) {
+   		this(shelf, resolve, tidy, false);
+	}
+	
+	@Deprecated
 	public UnshelveBuilder(String shelf, String resolve) {
 		this(shelf, resolve, false, false);
 	}

--- a/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder.java
@@ -98,6 +98,14 @@ public class UnshelveBuilder extends Builder {
 
 		// Expand shelf ${VAR} as needed and set as LABEL
 		String id = ws.getExpand().format(shelf, false);
+		
+		//	GOD BLESS FGOL AND HACKY CODE!
+		if (id == null || id.isEmpty())
+		{
+			logger.warning("Shelf list ID is empty or null, we will be skipping this task.");
+			return true;
+		}
+		
 		int change = Integer.parseInt(id);
 		task.setShelf(change);
 		task.setWorkspace(ws);

--- a/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilderStep.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilderStep.java
@@ -15,15 +15,15 @@ public class UnshelveBuilderStep extends UnshelveBuilder implements SimpleBuildS
 	private String credential;
 	private Workspace workspace;
 
-	public UnshelveBuilderStep(String credential, Workspace workspace, String shelf, String resolve, boolean tidy) {
-		super(shelf, resolve, tidy);
+	public UnshelveBuilderStep(String credential, Workspace workspace, String shelf, String resolve, boolean tidy, boolean ignoreEmpty) {
+		super(shelf, resolve, tidy, ignoreEmpty);
 		this.credential = credential;
 		this.workspace = workspace;
 	}
 
 	@Deprecated
 	public UnshelveBuilderStep(String shelf, String resolve) {
-		super(shelf, resolve, false);
+		super(shelf, resolve, false, false);
 	}
 
 	@Override

--- a/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilderStep.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilderStep.java
@@ -20,6 +20,11 @@ public class UnshelveBuilderStep extends UnshelveBuilder implements SimpleBuildS
 		this.credential = credential;
 		this.workspace = workspace;
 	}
+	
+	@Deprecated
+	public UnshelveBuilderStep(String credential, Workspace workspace, String shelf, String resolve, boolean tidy) {
+		this(null, null, shelf, resolve, tidy, false);
+	}
 
 	@Deprecated
 	public UnshelveBuilderStep(String shelf, String resolve) {

--- a/src/main/java/org/jenkinsci/plugins/p4/workflow/P4UnshelveStep.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/workflow/P4UnshelveStep.java
@@ -33,19 +33,21 @@ public class P4UnshelveStep extends Step {
 	private final String shelf;
 	private final String resolve;
 	private final boolean tidy;
+	private final boolean ignoreEmpty;
 
 	@DataBoundConstructor
-	public P4UnshelveStep(String credential, Workspace workspace, String shelf, String resolve, boolean tidy) {
+	public P4UnshelveStep(String credential, Workspace workspace, String shelf, String resolve, boolean tidy, boolean ignoreEmpty) {
 		this.credential = credential;
 		this.workspace = workspace;
 		this.shelf = shelf;
 		this.resolve = resolve;
 		this.tidy = tidy;
+		this.ignoreEmpty = ignoreEmpty;
 	}
 
 	@Deprecated
 	public P4UnshelveStep(String shelf, String resolve) {
-		this(null, null, shelf, resolve, false);
+		this(null, null, shelf, resolve, false, false);
 	}
 
 	@Override
@@ -71,6 +73,10 @@ public class P4UnshelveStep extends Step {
 
 	public boolean isTidy() {
 		return tidy;
+	}
+	
+	public boolean isIgnoreEmpty(){
+		return ignoreEmpty;
 	}
 
 	@Extension(optional = true)
@@ -118,7 +124,7 @@ public class P4UnshelveStep extends Step {
 
 		@Override
 		protected Void run() throws Exception {
-			UnshelveBuilderStep unshelve = new UnshelveBuilderStep(step.getCredential(), step.getWorkspace(), step.getShelf(), step.getResolve(), step.isTidy());
+			UnshelveBuilderStep unshelve = new UnshelveBuilderStep(step.getCredential(), step.getWorkspace(), step.getShelf(), step.getResolve(), step.isTidy(), step.isIgnoreEmpty());
 			unshelve.perform(getContext().get(Run.class), getContext().get(FilePath.class), getContext().get(Launcher.class), getContext().get(TaskListener.class));
 			return null;
 		}

--- a/src/main/java/org/jenkinsci/plugins/p4/workflow/P4UnshelveStep.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/workflow/P4UnshelveStep.java
@@ -46,6 +46,11 @@ public class P4UnshelveStep extends Step {
 	}
 
 	@Deprecated
+	public P4UnshelveStep(String credential, Workspace workspace, String shelf, String resolve, boolean tidy) {
+		this(null, null, shelf, resolve, false, false, false);
+	}
+	
+	@Deprecated
 	public P4UnshelveStep(String shelf, String resolve) {
 		this(null, null, shelf, resolve, false, false);
 	}

--- a/src/main/java/org/jenkinsci/plugins/p4/workflow/P4UnshelveStep.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/workflow/P4UnshelveStep.java
@@ -47,7 +47,7 @@ public class P4UnshelveStep extends Step {
 
 	@Deprecated
 	public P4UnshelveStep(String credential, Workspace workspace, String shelf, String resolve, boolean tidy) {
-		this(null, null, shelf, resolve, false, false, false);
+		this(null, null, shelf, resolve, tidy, false);
 	}
 	
 	@Deprecated

--- a/src/main/resources/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/unshelve/UnshelveBuilder/config.jelly
@@ -12,5 +12,9 @@
 	<f:entry field="tidy">
 		<f:checkbox title="${%Clean up Review actions}" default="false"/>
 	</f:entry>
+	
+	<f:entry field="ignoreEmpty">
+		<f:checkbox title="Ignore this step if ChangeList value not set." default="false"/>
+	</f:entry>
 
 </j:jelly>


### PR DESCRIPTION
**What:**
Added a checkbox to unshelve build step to skip itself if changelist ID was not entered.
Basically it just returns true in this case and build can continue.

**Why:**
Our build pipeline is quite complex, and the templates and parametric builds are used everywhere.

Currently the build would fail if the changelist ID is not set, as the plugin would actually try to parse null value. 

Since our tasks are instances of a master template that meant this value has to always be set, so we had to maintain couple of different templates if we wanted changelist unshelve option included.

With this we can have single template with option define in child task that implements it.
