### PR TITLE
Manually delete exclusively locked files for reviews

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -839,11 +839,14 @@ public class ClientHelper extends ConnectionHelper {
     private void deleteFile(String rev) throws Exception {
         List<IFileSpec> file = FileSpecBuilder.makeFileSpecList(rev);
         
-        String localPath = depotToLocal(file.get(0));
-        File target = new File(localPath);
+        String local = depotToLocal(file.get(0));
+        File unlink = new File(local);
         
-        if (target.exists()) {
-            target.delete();
+        if (unlink.exists()) {
+            boolean ok = unlink.delete();
+            if (!ok) {
+                log("Not able to delete: " + local);
+            }
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -835,6 +835,17 @@ public class ClientHelper extends ConnectionHelper {
 		String path = lSpec.get(0).getLocalPathString();
 		return path;
 	}
+    
+    private void deleteFile(String rev) throws Exception {
+        List<IFileSpec> file = FileSpecBuilder.makeFileSpecList(rev);
+        
+        String localPath = depotToLocal(file.get(0));
+        File target = new File(localPath);
+        
+        if (target.exists()) {
+            target.delete();
+        }
+    }
 
 	private void printFile(String rev) throws Exception {
 		byte[] buf = new byte[1024 * 64];
@@ -896,8 +907,16 @@ public class ClientHelper extends ConnectionHelper {
 				String msg = spec.getStatusMessage();
 				if (msg.contains("exclusive file already opened")) {
 					String rev = msg.substring(0, msg.indexOf(" - can't "));
-					// JENKINS-37868 use '@= + review' for correct file
-					printFile(rev + "@=" + review);
+					if (msg.contains("can't delete")) {
+						// JENKINS-47141 delete workspace file manually when locked
+						log("P4 Task: delete: " + rev);
+						deleteFile(rev);
+					}
+					else {
+						// JENKINS-37868 use '@= + review' for correct file
+						log("P4 Task: print: " + rev);
+						printFile(rev + "@=" + review);                        
+					}
 				}
 			} else {
 				log(spec.getDepotPathString());


### PR DESCRIPTION
JENKINS-47141 - Fixes a NullPointerException when trying to unshelve (print) deletes of exclusively locked files