### PR TITLE
[FIX JENKINS-34052] Poll for concurrent jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/tagging/TagAction.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tagging/TagAction.java
@@ -262,7 +262,7 @@ public class TagAction extends AbstractScmTagAction {
 		// Workaround for JENKINS-40722
 		do {
 			actions = lastActions(run);
-		} while(actions == null && run.isBuilding());
+		} while(actions == null && run != null && run.isBuilding());
 
 
 		if (actions == null || syncID == null || syncID.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/p4/tagging/TagAction.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tagging/TagAction.java
@@ -257,7 +257,14 @@ public class TagAction extends AbstractScmTagAction {
 	public static List<P4Ref> getLastChange(Run<?, ?> run, TaskListener listener, String syncID) {
 		List<P4Ref> changes = new ArrayList<>();
 
-		List<TagAction> actions = lastActions(run);
+		List<TagAction> actions;
+		// Check for actions until the build is complete
+		// Workaround for JENKINS-40722
+		do {
+			actions = lastActions(run);
+		} while(actions == null && run.isBuilding());
+
+
 		if (actions == null || syncID == null || syncID.isEmpty()) {
 			listener.getLogger().println("No previous build found...");
 			return changes;
@@ -305,6 +312,7 @@ public class TagAction extends AbstractScmTagAction {
 
 		// get last action, if no previous action then build now.
 		List<TagAction> actions = run.getActions(TagAction.class);
+
 		if (actions.isEmpty()) {
 			return null;
 		}


### PR DESCRIPTION
This fixes https://issues.jenkins-ci.org/browse/JENKINS-34052 and removes the need for https://issues.jenkins-ci.org/browse/JENKINS-41849. There is discussion in JENKINS-41849 about this being optional (as its definitely breaking backwards compatibility). Definitely up to the maintainer whether or not this should be optional or the new default.