### PR TITLE
JENKINS-48845 : Backward compatibility for pre-swarm P4 releases

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeParser.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeParser.java
@@ -4,6 +4,7 @@ import com.perforce.p4java.core.IChangelistSummary;
 import com.perforce.p4java.core.IFix;
 import com.perforce.p4java.core.file.FileAction;
 import com.perforce.p4java.exception.P4JavaException;
+import com.perforce.p4java.exception.RequestException;
 import com.perforce.p4java.impl.generic.core.Fix;
 import hudson.model.Run;
 import hudson.scm.ChangeLogParser;
@@ -70,9 +71,16 @@ public class P4ChangeParser extends ChangeLogParser {
 			this.p4 = new ConnectionHelper(run, credential, null);
 
 			if (browser == null) {
-				String url = p4.getSwarm();
-				if (url != null) {
-					this.browser = new SwarmBrowser(url);
+				try {
+					String url = p4.getSwarm();
+					if (url != null) {
+						this.browser = new SwarmBrowser(url);
+					}
+				} catch(RequestException re) {
+					if(re.getMessage() != null && !re.getMessage().contains("Unknown command")) {
+						throw re;
+					}
+					// else : Ignore, the command is not supported by older P4 versions
 				}
 			}
 		}


### PR DESCRIPTION
This is my proposed fix for [JENKINS-48845](https://issues.jenkins-ci.org/browse/JENKINS-48845).

Basically, if the getSwarm() throws a RequestException for which the message contains "Unknown command", we deduce the P4 version doesn't support the Swarm stuff yet, and we let it slide.

I applied this fix to the 1.8.4 release, compiled and installed it on our production Jenkins, and it works.