### PR TITLE
Implementing a Java Pattern filter for polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ vagrant/
 
 docs/ppt/
 
-tmp-JenkinsfileTest-p4root/
+tmp*

--- a/src/main/resources/org/jenkinsci/plugins/p4/filters/FilterPatternListImpl/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/filters/FilterPatternListImpl/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+	<f:entry title="${%Perforce Pattern List}" field="patternList">
+		<f:textarea/>
+	</f:entry>
+	
+	<f:entry field="caseSensitive">
+		<f:checkbox title="${%Case Sensitive}"/>
+	</f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/p4/filters/FilterPatternListImpl/help-patternList.html
+++ b/src/main/resources/org/jenkinsci/plugins/p4/filters/FilterPatternListImpl/help-patternList.html
@@ -1,0 +1,76 @@
+<div>
+	<b>Java Pattern filter</b>
+	<p>Changes can be filtered to not trigger a build; if none of the files
+		within a change match a Java pattern (regular expression) listed, the build is filtered.</p>
+	<p style="margin-left: 30.0px;">
+		For example, with the following regular expressions:
+		<br/>
+		<code style="margin-left: 60.0px;">//depot/main/tests/.*</code>
+		<br/>
+		<code style="margin-left: 60.0px;">//depot/main/src/.*\.cpp$</code>
+		<br/>
+		<code style="margin-left: 60.0px;">//depot/main/build/.*(?:\.rb|\.py|\.bat|Jenkinsfile)$</code>
+		<br/>
+		<code style="margin-left: 60.0px;">//depot/main/lib/(?!Lib1|Lib2).*</code>
+		<br/>
+	</p>
+	<p style="margin-left: 60.0px;">
+		<strong>Case A</strong> (change will not be filtered, as these files match
+		our first pattern on "tests"):
+	</p>
+	<p style="margin-left: 90.0px;">Files:</p>
+	<ul>
+		<li style="margin-left: 90.0px;"><code>//depot/main/tests/CONTRIUBTING.md</code>
+		</li>
+		<li style="margin-left: 90.0px;"><code>//depot/main/tests/001/index.xml</code>
+		</li>
+
+	</ul>
+	<p style="margin-left: 60.0px;">
+		<strong>Case B</strong> (Be careful with incomplete file paths! Change will NOT be filtered, 
+		<br />as this file matches a pattern which was likely intended as describing a <strong>"tests/"</strong> directory.)
+	</p>
+	<p style="margin-left: 90.0px;">Files:</p>
+	<ul>
+		<li style="margin-left: 90.0px;"><code>//depot/main/tests.doc</code>
+		</li>
+	</ul>
+		<p style="margin-left: 60.0px;">
+		<strong>Case C</strong> (change will NOT be filtered, as all files
+		match our fourth pattern looking for script files in 'build/'):
+	</p>
+	<p style="margin-left: 90.0px;">Files:</p>
+	<ul>
+		<li style="margin-left: 90.0px;"><code>//depot/main/build/rbs/deploy_server.rb</code>
+		</li>
+		<li style="margin-left: 90.0px;"><code>//depot/main/build/deploy/deploy.bat</code>
+		</li>
+		<li style="margin-left: 90.0px;"><code>//depot/main/build/Jenkinsfile</code>
+		</li>
+	</ul>
+	<p style="margin-left: 60.0px;">
+		<strong>Case D</strong> (change will be filtered, as no file matches our
+		second pattern for ".cpp" files under "main/src"):
+	</p>
+	<p style="margin-left: 90.0px;">Files:</p>
+	<ul>
+		<li style="margin-left: 90.0px;"><code>//depot/main/src/howto.doc</code>
+		</li>
+		<li style="margin-left: 90.0px;"><code>//depot/main/src/oldmain.c</code>
+		</li>
+		<li style="margin-left: 90.0px;"><code>//depot/main/src/art/splash.bmp</code>
+		</li>
+		<li style="margin-left: 90.0px;"><code>//depot/main/src/bt/funnelcake.php</code>
+		</li>
+	</ul>
+	<p style="margin-left: 60.0px;">
+		<strong>Case E</strong> (change will be filtered. Lib1 is included in a negative lookahead, and thus is excluded.)
+	</p>
+	<p style="margin-left: 90.0px;">Files:</p>
+	<ul>
+		<li style="margin-left: 90.0px;"><code>//depot/main/lib/Lib1/build.xml</code>
+		</li>
+	</ul>
+
+
+</div>


### PR DESCRIPTION
The ViewMask filter leaves a LOT to be desired, especially if you want a lot of control on SCM polling such as on certain filetypes. This filter should give a large amount of control via Java regular expressions (patterns).

The only thing I couldn't figure out how to do was implement Console logging when I detected an improper Pattern from my filter class (ideally we could even catch this in the test and ensure the logging is there). Would love to hear any advice on how to accomplish that.