### PR TITLE
Make sure branch is not discovered when a Jenkinsfile has been removed.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
@@ -629,7 +629,7 @@ public class ConnectionHelper implements AutoCloseable {
 
 	public boolean hasFile(String depotPath) throws Exception {
 		List<IFileSpec> files = FileSpecBuilder.makeFileSpecList(depotPath);
-		GetDepotFilesOptions opts = new GetDepotFilesOptions();
+		GetDepotFilesOptions opts = new GetDepotFilesOptions("-e");
 		List<IFileSpec> specs = connection.getDepotFiles(files, opts);
 		return validate.checkCatch(specs, "");
 	}


### PR DESCRIPTION
With multibranch pipelines, when one of the branches contains a deleted Jenkinsfile, a project is created anyway for this branch, and the build fails.

With this fix, we're making sure that the Jenkinsfile is available before creating the branch. Tested on Jenkins.

I had trouble adding automated tests for this: I found tests where a file is submitted, but I can't seem to figure out how I can simulate a file deletion.