### PR TITLE
Fix issue unshelving move/delete of locked files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -937,7 +937,7 @@ public class ClientHelper extends ConnectionHelper {
 				String msg = spec.getStatusMessage();
 				if (msg.contains("exclusive file already opened")) {
 					String rev = msg.substring(0, msg.indexOf(" - can't "));
-					if (msg.contains("can't delete")) {
+					if (msg.contains("can't delete") || msg.contains("can't move/delete")) {
 						// JENKINS-47141 delete workspace file manually when locked
 						log("P4 Task: delete: " + rev);
 						deleteFile(rev);


### PR DESCRIPTION
Added check for "can't move/delete" in addition to the existing "can't delete" check.