### PR TITLE
Add CrumbExclusion for /p4/change

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Hook.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Hook.java
@@ -27,6 +27,8 @@ public class P4Hook implements UnprotectedRootAction {
 
 	ExecutorService executorService = Executors.newSingleThreadExecutor();
 
+	public static final String URLNAME = "p4";
+
 	@Override
 	public String getIconFileName() {
 		return "/plugin/p4/icons/helix-24px.png";
@@ -39,7 +41,7 @@ public class P4Hook implements UnprotectedRootAction {
 
 	@Override
 	public String getUrlName() {
-		return "p4";
+		return URLNAME;
 	}
 
 	public void doChange(StaplerRequest req) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/p4/trigger/P4HookCrumbExclusion.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/trigger/P4HookCrumbExclusion.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.p4.trigger;
+
+import hudson.Extension;
+import hudson.security.csrf.CrumbExclusion;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@Extension
+public class P4HookCrumbExclusion extends CrumbExclusion {
+
+	@Override
+	public boolean process(HttpServletRequest req, HttpServletResponse resp, FilterChain chain)
+		throws IOException, ServletException {
+		String pathInfo = req.getPathInfo();
+
+		if (pathInfo == null) {
+			return false;
+		}
+
+		if (pathInfo.equals(getExclusionPath())) {
+			chain.doFilter(req, resp);
+			return true;
+		}
+
+		return false;
+	}
+
+	public String getExclusionPath() {
+		return "/" + P4Hook.URLNAME + "/change";
+	}
+}


### PR DESCRIPTION
Triggering p4 scans should not require an account nor convoluted scripting. Add a CrumbExclusion on `/p4/change`, like Github and BitBucket have done:

https://github.com/jenkinsci/github-plugin/commit/5c2a04169171cb8e36da7ba39c4003aa318c74cb
https://github.com/jenkinsci/bitbucket-plugin/compare/924bdd21c704...67fb8b71eea7