### PR TITLE
[JENKINS-53221] Add P4_ROOT to environment variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor.java
@@ -7,14 +7,14 @@ import hudson.model.EnvironmentContributor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
+import java.io.IOException;
+import java.util.Map;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.p4.PerforceScm;
 import org.jenkinsci.plugins.p4.review.P4Review;
 import org.jenkinsci.plugins.p4.tagging.TagAction;
-
-import java.io.IOException;
-import java.util.Map;
+import org.jenkinsci.plugins.p4.workspace.Workspace;
 
 @Extension()
 public class P4EnvironmentContributor extends EnvironmentContributor {
@@ -53,6 +53,14 @@ public class P4EnvironmentContributor extends EnvironmentContributor {
 		if (tagAction.getPort() != null) {
 			String port = tagAction.getPort();
 			env.put("P4_PORT", port);
+		}
+
+		// Set P4_ROOT value
+		if (tagAction.getWorkspace() != null) {
+			Workspace tagWorkspace = tagAction.getWorkspace();
+			if (tagWorkspace != null && tagWorkspace.getRootPath() != null) {
+				env.put("P4_ROOT", tagWorkspace.getRootPath());
+			}
 		}
 
 		// Set P4_USER connection

--- a/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.p4.PerforceScm;
 
 def l = namespace(lib.JenkinsTagLib)
 
-["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","HUDSON_CHANGELOG_FILE"].each { name ->
+["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","HUDSON_CHANGELOG_FILE"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
@@ -1,6 +1,7 @@
 P4_CHANGELIST.blurb=The last Perforce changelist number included in the populated workspace.
 P4_CLIENT.blurb=The Perforce client workspace name.
 P4_PORT.blurb=The Perforce server connection port (e.g. perforce:1666).
+P4_ROOT.blurb=The Perforce client workspace root path.
 P4_USER.blurb=The Perforce username.
 P4_TICKET.blurb=A valid Perforce ticket (if the credential is valid).
 P4_REVIEW.blurb=The Swarm Review ID.

--- a/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.p4.PerforceScm;
 
 def l = namespace(lib.JenkinsTagLib)
 
-["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","HUDSON_CHANGELOG_FILE"].each { name ->
+["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","HUDSON_CHANGELOG_FILE"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
@@ -1,6 +1,7 @@
 P4_CHANGELIST.blurb=The last Perforce changelist number included in the populated workspace.
 P4_CLIENT.blurb=The Perforce client workspace name.
 P4_PORT.blurb=The Perforce server connection port (e.g. perforce:1666).
+P4_ROOT.blurb=The Perforce client workspace root path.
 P4_USER.blurb=The Perforce username.
 P4_TICKET.blurb=A valid Perforce ticket (if the credential is valid).
 P4_REVIEW.blurb=The Swarm Review ID.


### PR DESCRIPTION
[JENKINS-53221] Add P4_ROOT to environment variables. Extracting the workspace root information from the tag action. https://issues.jenkins-ci.org/browse/JENKINS-53221