### PR TITLE
Avoid unnecessary call to TagAction.getTicket()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor.java
@@ -83,7 +83,7 @@ public class P4EnvironmentContributor extends EnvironmentContributor {
 			Descriptor<SCM> scm = j.getDescriptor(PerforceScm.class);
 			PerforceScm.DescriptorImpl p4scm = (PerforceScm.DescriptorImpl) scm;
 
-			if (tagAction.getTicket() != null && !p4scm.isHideTicket()) {
+			if (!p4scm.isHideTicket() && tagAction.getTicket() != null) {
 				String ticket = tagAction.getTicket();
 				env.put("P4_TICKET", ticket);
 			}

--- a/src/main/java/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor.java
@@ -83,7 +83,7 @@ public class P4EnvironmentContributor extends EnvironmentContributor {
 			Descriptor<SCM> scm = j.getDescriptor(PerforceScm.class);
 			PerforceScm.DescriptorImpl p4scm = (PerforceScm.DescriptorImpl) scm;
 
-			if (!p4scm.isHideTicket() && tagAction.getTicket() != null) {
+			if (p4scm != null && !p4scm.isHideTicket() && tagAction.getTicket() != null) {
 				String ticket = tagAction.getTicket();
 				env.put("P4_TICKET", ticket);
 			}


### PR DESCRIPTION
There seems to be no reason to call TagAction.getTicket() in P4EnvironmentContributor if tickets are set to be hidden. So let's not, since it's a potentially expensive operation (less so since 83baa531 but still).