### PR TITLE
Changed P4Ticket web field type to password

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/p4/credentials/P4TicketImpl/credentials.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/credentials/P4TicketImpl/credentials.jelly
@@ -19,7 +19,7 @@
 		
 	<f:radioBlock name="ticket" value="ticketValueSet" title="${%Login with ticket value}" checked="${instance.isTicketValueSet()}">
 		<f:entry title="${%Ticket}" field="ticketValue">
-			<f:textbox/>
+			<f:password/>
 		</f:entry>
 	</f:radioBlock>
 	<f:radioBlock name="ticket" value="ticketPathSet" title="${%Use P4TICKETS file}" checked="${instance.isTicketPathSet()}">


### PR DESCRIPTION
This change tells the Web UI to treat the P4Ticket field as a password, instead of treating it as plain text.