### PR TITLE
[JENKINS-56290] Impossible to Add Streams with Exact Names to Multibranch Pipeline

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
@@ -396,14 +396,6 @@ public class ConnectionHelper implements AutoCloseable {
 	 * @throws Exception push up stack
 	 */
 	public List<IStreamSummary> getStreams(List<String> paths) throws Exception {
-		ListIterator<String> list = paths.listIterator();
-		while (list.hasNext()) {
-			String i = list.next();
-			if (!i.contains("...") && !i.contains("*")) {
-				list.set(i + "*");
-			}
-		}
-
 		GetStreamsOptions opts = new GetStreamsOptions();
 		List<IStreamSummary> streams = connection.getStreams(paths, opts);
 		return streams;

--- a/src/main/resources/org/jenkinsci/plugins/p4/scm/StreamsScmSource/help-includes.html
+++ b/src/main/resources/org/jenkinsci/plugins/p4/scm/StreamsScmSource/help-includes.html
@@ -1,5 +1,6 @@
 <div>
 	<p>A List of Perforce depot paths to one or more Streams (separated by new lines).  The plugin will recursively search for a
 		<code>Jenkinsfile</code> (or defined item) using the Stream name for the multi-branch name.</p>
+	<p><code>...</code> or <code>*</code> can be used as wildcards in Perforce depot paths.</p>
 	<p>For example: <code>//streams/...</code></p>
 </div>


### PR DESCRIPTION
Fix for https://issues.jenkins-ci.org/browse/JENKINS-56290