### PR TITLE
[JENKINS-58504] Only set the script path for pipeline script checkout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
@@ -623,6 +623,10 @@ public class PerforceScm extends SCM {
 		}
 
 		CpsScmFlowDefinition cps = (CpsScmFlowDefinition) definition;
+		if(!this.equals(cps.getScm())) {
+			return null;
+		}
+
 		return cps.getScriptPath();
 	}
 


### PR DESCRIPTION
See [JENKINS-58504](https://issues.jenkins-ci.org/browse/JENKINS-58504)

Some use cases where the issue occurs include:
1) Using PerforceSCM to checkout a Jenkinsfile, followed by additional PerforceSCM checkouts
2) Using another SCM to checkout a Jenkinsfile, followed by additional PerforceSCM checkouts

In either case, each of the additional PerforceSCM checkouts will retrieve the Jenkinsfile/Pipeline script path from the `CpsScmFlowDefinition` and run `p4 where <scriptPath>`. Since the clients for these additional checkouts don't include the Jenkinsfile, the `p4 where` command returns `file(s) not in client view.`