### PR TITLE
Credentials handling for Folders when using P4Groovy.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/credentials/P4InvalidCredentialException.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/credentials/P4InvalidCredentialException.java
@@ -5,7 +5,4 @@ public class P4InvalidCredentialException extends Exception {
 	public P4InvalidCredentialException() {
 		super("Invalid credentials");
 	}
-	public P4InvalidCredentialException( String message) {
-		super("Invalid credentials: " + message);
-	}
 }

--- a/src/main/java/org/jenkinsci/plugins/p4/credentials/P4InvalidCredentialException.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/credentials/P4InvalidCredentialException.java
@@ -5,4 +5,7 @@ public class P4InvalidCredentialException extends Exception {
 	public P4InvalidCredentialException() {
 		super("Invalid credentials");
 	}
+	public P4InvalidCredentialException( String message) {
+		super("Invalid credentials: " + message);
+	}
 }

--- a/src/main/java/org/jenkinsci/plugins/p4/groovy/GetP4.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/groovy/GetP4.java
@@ -60,7 +60,7 @@ public class GetP4 extends Builder implements SimpleBuildStep {
 		workspace.setRootPath(buildWorkspace.getRemote());
 
 		// Create Task
-		GetP4Task task = new GetP4Task(credential, workspace, buildWorkspace, listener, run);
+		GetP4Task task = new GetP4Task(run, credential, workspace, buildWorkspace, listener);
 
 		p4Groovy = buildWorkspace.act(task);
 	}

--- a/src/main/java/org/jenkinsci/plugins/p4/groovy/GetP4.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/groovy/GetP4.java
@@ -60,7 +60,7 @@ public class GetP4 extends Builder implements SimpleBuildStep {
 		workspace.setRootPath(buildWorkspace.getRemote());
 
 		// Create Task
-		GetP4Task task = new GetP4Task(credential, workspace, buildWorkspace, listener);
+		GetP4Task task = new GetP4Task(credential, workspace, buildWorkspace, listener, run);
 
 		p4Groovy = buildWorkspace.act(task);
 	}

--- a/src/main/java/org/jenkinsci/plugins/p4/groovy/GetP4Task.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/groovy/GetP4Task.java
@@ -4,37 +4,33 @@ import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.security.MasterToSlaveCallable;
-import org.jenkinsci.plugins.p4.workspace.Workspace;
+import org.jenkinsci.plugins.p4.client.ConnectionHelper;
 import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
+import org.jenkinsci.plugins.p4.workspace.Workspace;
 
 import java.io.Serializable;
-import org.jenkinsci.plugins.p4.client.ConnectionHelper;
 
 public class GetP4Task extends MasterToSlaveCallable<P4Groovy, InterruptedException> implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String credentialName;
+	private final P4BaseCredentials credential;
 	private final Workspace workspace;
 	private final FilePath buildWorkspace;
-	private final P4BaseCredentials p4Credential;
 
 	private final TaskListener listener;
 
-	public GetP4Task(String credentialName, Workspace workspace, FilePath buildWorkspace, 
-			TaskListener listener, Run run) {
-		this.credentialName = credentialName;
+	public GetP4Task(Run run, String credential, Workspace workspace, FilePath buildWorkspace, TaskListener listener) {
 		this.workspace = workspace;
 		this.listener = listener;
 		this.buildWorkspace = buildWorkspace;
-		
-		// TODO:  throw exception here if not found.
-		this.p4Credential = ConnectionHelper.findCredential(credentialName, run);
+
+		this.credential = ConnectionHelper.findCredential(credential, run);
 	}
 
 	@Override
 	public P4Groovy call() throws InterruptedException {
-		P4Groovy p4Groovy = new P4Groovy(credentialName, p4Credential, listener, workspace, buildWorkspace);
+		P4Groovy p4Groovy = new P4Groovy(credential, listener, workspace, buildWorkspace);
 		return p4Groovy;
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/p4/groovy/GetP4Task.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/groovy/GetP4Task.java
@@ -1,32 +1,40 @@
 package org.jenkinsci.plugins.p4.groovy;
 
 import hudson.FilePath;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.p4.workspace.Workspace;
+import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
 
 import java.io.Serializable;
+import org.jenkinsci.plugins.p4.client.ConnectionHelper;
 
 public class GetP4Task extends MasterToSlaveCallable<P4Groovy, InterruptedException> implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String credential;
+	private final String credentialName;
 	private final Workspace workspace;
 	private final FilePath buildWorkspace;
+	private final P4BaseCredentials p4Credential;
 
 	private final TaskListener listener;
 
-	public GetP4Task(String credential, Workspace workspace, FilePath buildWorkspace, TaskListener listener) {
-		this.credential = credential;
+	public GetP4Task(String credentialName, Workspace workspace, FilePath buildWorkspace, 
+			TaskListener listener, Run run) {
+		this.credentialName = credentialName;
 		this.workspace = workspace;
 		this.listener = listener;
 		this.buildWorkspace = buildWorkspace;
+		
+		// TODO:  throw exception here if not found.
+		this.p4Credential = ConnectionHelper.findCredential(credentialName, run);
 	}
 
 	@Override
 	public P4Groovy call() throws InterruptedException {
-		P4Groovy p4Groovy = new P4Groovy(credential, listener, workspace, buildWorkspace);
+		P4Groovy p4Groovy = new P4Groovy(credentialName, p4Credential, listener, workspace, buildWorkspace);
 		return p4Groovy;
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/p4/groovy/P4Groovy.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/groovy/P4Groovy.java
@@ -4,8 +4,8 @@ import com.perforce.p4java.exception.P4JavaException;
 import com.perforce.p4java.server.IOptionsServer;
 import hudson.FilePath;
 import hudson.model.TaskListener;
-import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.p4.client.ClientHelper;
+import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
 import org.jenkinsci.plugins.p4.workspace.Workspace;
 
 import java.io.IOException;
@@ -14,22 +14,19 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
 
 public class P4Groovy implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String credentialName;
+	private final P4BaseCredentials credential;
 	private final Workspace workspace;
 	private final FilePath buildWorkspace;
-	private final P4BaseCredentials p4Credential;
 
 	private transient TaskListener listener = null;
 
-	public P4Groovy(String credentialName, P4BaseCredentials p4Credential, TaskListener listener, Workspace workspace, FilePath buildWorkspace) {
-		this.credentialName = credentialName;
-		this.p4Credential = p4Credential;
+	public P4Groovy(P4BaseCredentials credential, TaskListener listener, Workspace workspace, FilePath buildWorkspace) {
+		this.credential = credential;
 		this.workspace = workspace;
 		this.listener = listener;
 		this.buildWorkspace = buildWorkspace;
@@ -59,7 +56,7 @@ public class P4Groovy implements Serializable {
 	}
 
 	public Map<String, Object>[] run(String cmd, String... args) throws P4JavaException, InterruptedException, IOException {
-		P4GroovyTask task = new P4GroovyTask(p4Credential, credentialName, listener, cmd, args);
+		P4GroovyTask task = new P4GroovyTask(credential, listener, cmd, args);
 		task.setWorkspace(workspace);
 
 		return buildWorkspace.act(task);
@@ -81,7 +78,7 @@ public class P4Groovy implements Serializable {
 		}
 		String[] args = list.toArray(new String[0]);
 
-		P4GroovyTask task = new P4GroovyTask(p4Credential, credentialName, listener, type, args, spec);
+		P4GroovyTask task = new P4GroovyTask(credential, listener, type, args, spec);
 		task.setWorkspace(workspace);
 
 		return buildWorkspace.act(task);
@@ -103,7 +100,7 @@ public class P4Groovy implements Serializable {
 	}
 
 	private IOptionsServer getConnection() throws IOException {
-		ClientHelper p4 = new ClientHelper(p4Credential, listener, workspace);
+		ClientHelper p4 = new ClientHelper(credential, listener, workspace);
 		return p4.getConnection();
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/p4/groovy/P4Groovy.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/groovy/P4Groovy.java
@@ -14,19 +14,22 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
 
 public class P4Groovy implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String credential;
+	private final String credentialName;
 	private final Workspace workspace;
 	private final FilePath buildWorkspace;
+	private final P4BaseCredentials p4Credential;
 
 	private transient TaskListener listener = null;
 
-	public P4Groovy(String credential, TaskListener listener, Workspace workspace, FilePath buildWorkspace) {
-		this.credential = credential;
+	public P4Groovy(String credentialName, P4BaseCredentials p4Credential, TaskListener listener, Workspace workspace, FilePath buildWorkspace) {
+		this.credentialName = credentialName;
+		this.p4Credential = p4Credential;
 		this.workspace = workspace;
 		this.listener = listener;
 		this.buildWorkspace = buildWorkspace;
@@ -56,7 +59,7 @@ public class P4Groovy implements Serializable {
 	}
 
 	public Map<String, Object>[] run(String cmd, String... args) throws P4JavaException, InterruptedException, IOException {
-		P4GroovyTask task = new P4GroovyTask(credential, listener, cmd, args);
+		P4GroovyTask task = new P4GroovyTask(p4Credential, credentialName, listener, cmd, args);
 		task.setWorkspace(workspace);
 
 		return buildWorkspace.act(task);
@@ -78,7 +81,7 @@ public class P4Groovy implements Serializable {
 		}
 		String[] args = list.toArray(new String[0]);
 
-		P4GroovyTask task = new P4GroovyTask(credential, listener, type, args, spec);
+		P4GroovyTask task = new P4GroovyTask(p4Credential, credentialName, listener, type, args, spec);
 		task.setWorkspace(workspace);
 
 		return buildWorkspace.act(task);
@@ -100,7 +103,7 @@ public class P4Groovy implements Serializable {
 	}
 
 	private IOptionsServer getConnection() throws IOException {
-		ClientHelper p4 = new ClientHelper(Jenkins.getActiveInstance(), credential, listener, workspace);
+		ClientHelper p4 = new ClientHelper(p4Credential, listener, workspace);
 		return p4.getConnection();
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/p4/groovy/P4GroovyTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/groovy/P4GroovyTask.java
@@ -8,6 +8,7 @@ import org.jenkinsci.plugins.p4.client.ClientHelper;
 import org.jenkinsci.plugins.p4.tasks.AbstractTask;
 import org.jenkinsci.remoting.RoleChecker;
 import org.jenkinsci.remoting.RoleSensitive;
+import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,15 +27,15 @@ public class P4GroovyTask extends AbstractTask implements FileCallable<Map<Strin
 	private final String[] args;
 	private final Map<String, Object> spec;
 
-	public P4GroovyTask(String credential, TaskListener listener, String cmd, String[] args, Map<String, Object> spec) {
-		super(credential, listener);
+	public P4GroovyTask(P4BaseCredentials p4Credential, String credentialName, TaskListener listener, String cmd, String[] args, Map<String, Object> spec) {
+		super(p4Credential, credentialName, listener);
 		this.cmd = cmd;
 		this.args = Arrays.copyOf(args, args.length);
 		this.spec = spec;
 	}
 
-	public P4GroovyTask(String credential, TaskListener listener, String cmd, String... args) {
-		this(credential, listener, cmd, args, null);
+	public P4GroovyTask(P4BaseCredentials p4Credential, String credentialName, TaskListener listener, String cmd, String... args) {
+		this(p4Credential, credentialName, listener, cmd, args, null);
 	}
 
 	@Override

--- a/src/main/java/org/jenkinsci/plugins/p4/groovy/P4GroovyTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/groovy/P4GroovyTask.java
@@ -5,10 +5,10 @@ import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import jenkins.security.Roles;
 import org.jenkinsci.plugins.p4.client.ClientHelper;
+import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
 import org.jenkinsci.plugins.p4.tasks.AbstractTask;
 import org.jenkinsci.remoting.RoleChecker;
 import org.jenkinsci.remoting.RoleSensitive;
-import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,15 +27,15 @@ public class P4GroovyTask extends AbstractTask implements FileCallable<Map<Strin
 	private final String[] args;
 	private final Map<String, Object> spec;
 
-	public P4GroovyTask(P4BaseCredentials p4Credential, String credentialName, TaskListener listener, String cmd, String[] args, Map<String, Object> spec) {
-		super(p4Credential, credentialName, listener);
+	public P4GroovyTask(P4BaseCredentials credential, TaskListener listener, String cmd, String[] args, Map<String, Object> spec) {
+		super(credential, listener);
 		this.cmd = cmd;
 		this.args = Arrays.copyOf(args, args.length);
 		this.spec = spec;
 	}
 
-	public P4GroovyTask(P4BaseCredentials p4Credential, String credentialName, TaskListener listener, String cmd, String... args) {
-		this(p4Credential, credentialName, listener, cmd, args, null);
+	public P4GroovyTask(P4BaseCredentials credential, TaskListener listener, String cmd, String... args) {
+		this(credential, listener, cmd, args, null);
 	}
 
 	@Override

--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/AbstractTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/AbstractTask.java
@@ -28,23 +28,33 @@ public abstract class AbstractTask implements Serializable {
 	private static Logger logger = Logger.getLogger(AbstractTask.class.getName());
 
 	private final P4BaseCredentials credential;
+	private final String credentialName;
 	private final TaskListener listener;
 
 	private Workspace workspace;
 
 	@Deprecated
-	public AbstractTask(String credential, TaskListener listener) {
-		this.credential = ConnectionHelper.findCredential(credential);
+	public AbstractTask(String credentialName, TaskListener listener) {
+		this.credential = ConnectionHelper.findCredential(credentialName);
+		this.credentialName = credentialName;
 		this.listener = listener;
 	}
 
-	public AbstractTask(String credential, Item project, TaskListener listener) {
-		this.credential = ConnectionHelper.findCredential(credential, project);
+	public AbstractTask(P4BaseCredentials p4Credential, String credentialName, TaskListener listener) {
+		this.credential = p4Credential;
+		this.credentialName = credentialName;
+		this.listener = listener;
+	}
+	
+	public AbstractTask(String credentialName, Item project, TaskListener listener) {
+		this.credential = ConnectionHelper.findCredential(credentialName, project);
+		this.credentialName = credentialName;
 		this.listener = listener;
 	}
 
-	public AbstractTask(String credential, Run run, TaskListener listener) {
-		this.credential = ConnectionHelper.findCredential(credential, run);
+	public AbstractTask(String credentialName, Run run, TaskListener listener) {
+		this.credential = ConnectionHelper.findCredential(credentialName, run);
+		this.credentialName = credentialName;
 		this.listener = listener;
 	}
 
@@ -69,7 +79,7 @@ public abstract class AbstractTask implements Serializable {
 
 	public P4BaseCredentials getCredential() throws P4InvalidCredentialException {
 		if(credential == null){
-			throw new P4InvalidCredentialException();
+			throw new P4InvalidCredentialException( "credential '" + credentialName + "' not found.");
 		}
 		return credential;
 	}

--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/AbstractTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/AbstractTask.java
@@ -28,33 +28,28 @@ public abstract class AbstractTask implements Serializable {
 	private static Logger logger = Logger.getLogger(AbstractTask.class.getName());
 
 	private final P4BaseCredentials credential;
-	private final String credentialName;
 	private final TaskListener listener;
 
 	private Workspace workspace;
 
 	@Deprecated
-	public AbstractTask(String credentialName, TaskListener listener) {
-		this.credential = ConnectionHelper.findCredential(credentialName);
-		this.credentialName = credentialName;
+	public AbstractTask(String credential, TaskListener listener) {
+		this.credential = ConnectionHelper.findCredential(credential);
 		this.listener = listener;
 	}
 
-	public AbstractTask(P4BaseCredentials p4Credential, String credentialName, TaskListener listener) {
-		this.credential = p4Credential;
-		this.credentialName = credentialName;
-		this.listener = listener;
-	}
-	
-	public AbstractTask(String credentialName, Item project, TaskListener listener) {
-		this.credential = ConnectionHelper.findCredential(credentialName, project);
-		this.credentialName = credentialName;
+	public AbstractTask(P4BaseCredentials credential, TaskListener listener) {
+		this.credential = credential;
 		this.listener = listener;
 	}
 
-	public AbstractTask(String credentialName, Run run, TaskListener listener) {
-		this.credential = ConnectionHelper.findCredential(credentialName, run);
-		this.credentialName = credentialName;
+	public AbstractTask(String credential, Item project, TaskListener listener) {
+		this.credential = ConnectionHelper.findCredential(credential, project);
+		this.listener = listener;
+	}
+
+	public AbstractTask(String credential, Run run, TaskListener listener) {
+		this.credential = ConnectionHelper.findCredential(credential, run);
 		this.listener = listener;
 	}
 
@@ -79,7 +74,7 @@ public abstract class AbstractTask implements Serializable {
 
 	public P4BaseCredentials getCredential() throws P4InvalidCredentialException {
 		if(credential == null){
-			throw new P4InvalidCredentialException( "credential '" + credentialName + "' not found.");
+			throw new P4InvalidCredentialException();
 		}
 		return credential;
 	}

--- a/src/test/java/org/jenkinsci/plugins/p4/groovy/P4GroovyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/groovy/P4GroovyTest.java
@@ -24,7 +24,7 @@ public class P4GroovyTest extends DefaultEnvironment {
 	@Test
 	public void testInvalidCredentials() {
 		StreamWorkspaceImpl ws = new StreamWorkspaceImpl(null, false, "//stream/main", "job1-temp-branch1");
-		P4Groovy p4 = new P4Groovy("bad credential", null, null, ws, new FilePath(new File("workspace")));
+		P4Groovy p4 = new P4Groovy(null, null, ws, new FilePath(new File("workspace")));
 		try {
 			Map<String, Object>[] result = p4.run("status");
 		} catch (Exception e) {

--- a/src/test/java/org/jenkinsci/plugins/p4/groovy/P4GroovyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/groovy/P4GroovyTest.java
@@ -24,7 +24,7 @@ public class P4GroovyTest extends DefaultEnvironment {
 	@Test
 	public void testInvalidCredentials() {
 		StreamWorkspaceImpl ws = new StreamWorkspaceImpl(null, false, "//stream/main", "job1-temp-branch1");
-		P4Groovy p4 = new P4Groovy("bad credential", null, ws, new FilePath(new File("workspace")));
+		P4Groovy p4 = new P4Groovy("bad credential", null, null, ws, new FilePath(new File("workspace")));
 		try {
 			Map<String, Object>[] result = p4.run("status");
 		} catch (Exception e) {


### PR DESCRIPTION
Use run to determine the credentials in GetP4Task, then pass the P4BaseCredentials instead of the credentials ID.  

Now the P4Groovy getConnection() method uses the P4BaseCredentials instead of looking up the credentials from the active Jenkins instance.

JENKINS-58745 JENKINS-57314