### PR TITLE
Allow spacing around viewmappings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ViewMapHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ViewMapHelper.java
@@ -46,7 +46,7 @@ public class ViewMapHelper {
 		}
 
 		// Split on new line and trim any following white space
-		String[] lines = depotView.split("\n\\s*");
+		String[] lines = depotView.trim().split("\n\\s*");
 		boolean multi = lines.length > 1;
 		StringBuffer view = processLines(lines, client, multi, overlay);
 

--- a/src/test/java/org/jenkinsci/plugins/p4/client/ViewMapHelperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/ViewMapHelperTest.java
@@ -22,10 +22,12 @@ public class ViewMapHelperTest extends DefaultEnvironment {
     @Test
     public void testgetClientView_multipath_ok(){
         String multi_path = 
-            "\n//depot/Projects/Foo/Bar/Baz/Tick/Tock/...\n//depot/Projects/Foo/Bar/Baz/Tick/Tack/...\n";
+            "\n//depot/foo/...\n//depot/bar/...";
         String res = ViewMapHelper.getClientView(multi_path, "p4client", false);
         // String[] exp = new String[]{"depot", "Projects", "my-super-project" };
 
-        assertEquals("Depot path is equal", "Something", res);
+        String expected = "//depot/foo/... //p4client/depot/foo/...\n//depot/bar/... //p4client/depot/bar/...";
+
+        assertEquals(expected, res);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/p4/client/ViewMapHelperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/ViewMapHelperTest.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.p4.client;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.logging.Logger;
+
+import org.jenkinsci.plugins.p4.DefaultEnvironment;
+import org.junit.Test;
+
+public class ViewMapHelperTest extends DefaultEnvironment {
+    private static Logger logger = Logger.getLogger(ViewMapHelperTest.class.getName());
+    
+    @Test
+    public void testSplitDepotPath_singlepath_ok(){
+        String[] res = ViewMapHelper.splitDepotPath("//depot/Projects/my-super-project");
+        String[] exp = new String[]{"depot", "Projects", "my-super-project" };
+
+        assertArrayEquals("Depot path is equal", exp, res);
+    }
+
+    @Test
+    public void testgetClientView_multipath_ok(){
+        String multi_path = 
+            "\n//depot/Projects/Foo/Bar/Baz/Tick/Tock/...\n//depot/Projects/Foo/Bar/Baz/Tick/Tack/...\n";
+        String res = ViewMapHelper.getClientView(multi_path, "p4client", false);
+        // String[] exp = new String[]{"depot", "Projects", "my-super-project" };
+
+        assertEquals("Depot path is equal", "Something", res);
+    }
+}


### PR DESCRIPTION
I'm epxeriencing an error where the viewmap helper fails to parse a multi-path depotSource, trying to reproduce in test.

First step was to get the tests running for a simple example.

To reproduce in the wild do something like this:

```
p4sync(
            charset: 'utf8',
            credential: 'CREDENTIALS',
            format: "this-is-my-workspace",
            populate: autoClean(
                delete: true,
                modtime: false,
                parallel: [enable: false, minbytes: '1024', minfiles: '1', threads: '4'],
                pin: '',
                quiet: true,
                replace: true,
                tidy: false
            ),
            source: depotSource("""
//depot/foo/...
//depot/bar/...
""")
        )
```
Notice the leading and trailing newlines, producing empty lines for the viewmapper.