### PR TITLE
Get list of jobs immediately prior to probing

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Hook.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Hook.java
@@ -78,7 +78,6 @@ public class P4Hook implements UnprotectedRootAction {
 
 			final String port = payload.getString("p4port");
 			//final String change = payload.getString("change");
-			final List<Job> jobs = getJobs();
 
 			LOGGER.info("Received trigger event for: " + port);
 			if (port == null) {
@@ -91,6 +90,7 @@ public class P4Hook implements UnprotectedRootAction {
 
 				@Override
 				public void run() {
+					final List<Job> jobs = getJobs();
 					try {
 						probeJobs(port, jobs);
 					} catch (IOException e) {


### PR DESCRIPTION
When the endpoint /change is triggered it immediately generates and stores a list of Jenkins jobs then queues a task in the executorService.  This can lead to problems in big installations where there are lots of jobs that rely on p4 triggers and the Perforce instance is very active.

Say for instance it takes 2mins for a task to run through a list of jobs and poke each one.  Then you get 10 trigger requests in rapid succession.  It'll take 18mins to get to the last task instance.  During this time it's possible for jobs to be added / removed that rely on the trigger mechanism.  If a job is added just after the 10 trigger requests were sent then in this example it'll take approx 18mins before that job is poked by the trigger mechanism.

In our worst case we saw a 2hr delay before new jobs were being poked by the polling mechanism, which is too much when developers are expecting their changes to trigger builds after they've created new jobs associated with them.

To work around this I've made a change to generate the list of jobs at the point when they are to be polled, that way, the list of jobs will be current at the time of polling.

This has been tested against our Jenkins instance and is working as expected.  Please could you consider it for inclusion into the official version of the plugin?