### PR TITLE
tagAction should not be written to config.xml

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
@@ -103,8 +103,8 @@ public class PerforceScm extends SCM {
 	private final P4Ref revision;
 
 	private String script;
-	private TagAction tagAction = null;
 
+	private transient TagAction tagAction = null;
 	private transient P4Ref parentChange;
 	private transient P4Review review;
 


### PR DESCRIPTION
Maven jobs, as well as some other plugins, update job config (config.xml) during the build. This is also the case when a job has been generated from DSL. After P4 checkout is complete, "tagAction" in PerforceScm is not null, and when a job is saved again it ends up being written to config.xml.

Steps to reproduce:

1. Create Maven job from DSL, using Perforce repository.
2. Start job, wait until P4 checkout is complete.
3. Check config.xml for the job; it will be reformatted from initial DSL representation, and will also have "tagAction" attribute under "scm" section.

This also causes NPE errors during Perforce checkout, under certain conditions, although these are much harder to reproduce. In any case, tagAction should be written to "Run" XMLs only, not build job configuration itself.