### PR TITLE
Initialize the cause of AbortException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/AbstractTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/AbstractTask.java
@@ -186,7 +186,12 @@ public abstract class AbstractTask implements Serializable {
 		} catch (Exception e) {
 			String msg = "P4: Task Exception: " + e.getMessage();
 			logger.severe(msg);
-			throw new AbortException(msg);
+			AbortException ae = new AbortException(msg);
+			// AbortExceptions don't have a constructor with a cause.  We want to include the cause for debugging
+			// purposes so advanced developers can print the stack trace without changing the legacy behavior of
+			// returning an AbortException (which has specific implications for Jenkins).
+			ae.initCause(e);
+			throw ae;
 		}
 	}
 


### PR DESCRIPTION
We are getting an abort exception with the message: "Unmarshalable value in RpcStreamConnection.marshal; type: java.lang.Long"  In order to debug this issue I want to see where its being thrown in the p4 plugin.  But the AbortException passed back doesn't contain its cause - so the original exception is lost.  I'd like to pass back the cause so advanced developers like us can more easily get the backtrace when its needed.  Shouldn't affect normal users since AbortException doesn't print a backtrace by default.