### PR TITLE
Remove background colour for change list

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/p4/changes/P4ChangeSet/digest.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/changes/P4ChangeSet/digest.jelly
@@ -10,16 +10,7 @@
             </b>
             <br/>
             <j:forEach var="c" items="${it.history}" varStatus="loop">
-                <j:choose>
-                    <j:when test="${c.shelved}">                                            
-                        <j:set var="divColor" value="background-color:white"/>
-                    </j:when>	
-                    <j:otherwise>
-                        <j:set var="divColor" value="background-color:#F5F0FA"/>
-                    </j:otherwise>
-                </j:choose>
-            
-                <div class="changeset-message" style="width: 650px; margin-bottom: 4px;${divColor}">  
+                <div class="changeset-message" style="width: 650px; margin-bottom: 4px; background-color: inherit">  
                     	
                     <j:choose>
                         <j:when test="${c.id == null}">

--- a/src/main/resources/org/jenkinsci/plugins/p4/changes/P4ChangeSet/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/changes/P4ChangeSet/index.jelly
@@ -15,17 +15,8 @@
                     </j:when>
 			
             
-                    <j:otherwise>
-                        <j:choose>
-                            <j:when test="${entry.shelved}">                                            
-                                <j:set var="divColor" value="background-color:white"/>
-                            </j:when>	
-                            <j:otherwise>
-                                <j:set var="divColor" value="background-color:#F5F0FA"/>
-                            </j:otherwise>
-                        </j:choose>
-                                                
-                        <div class="changeset-message" style="width: 650px; margin-bottom: 4px;${divColor}">  
+                    <j:otherwise>          
+                        <div class="changeset-message" style="width: 650px; margin-bottom: 4px; background-color: inherit">  
 
                             <a name="detail${loop.index}"></a>
                             <j:choose>


### PR DESCRIPTION
This should help support themes.
The drawback is now there's no visual differentiation between shelved/committed, but personally I don't see much value in that, and I wasn't sure how to do that without breaking IE compatibility.

I figured I'd log a PR to gauge interest.

The icons also need updating with transparency, but that can be a separate issue.