### PR TITLE
Use Github as source of documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <name>P4 Plugin</name>
   <description>Perforce Client plugin for the Jenkins SCM provider.</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/P4+Plugin</url>
+  <url>https://github.com/jenkinsci/p4-plugin</url>
 
   <properties>
     <jenkins.version>2.89.1</jenkins.version>


### PR DESCRIPTION
Load documentation from Github instead of the wiki.

Related tickets:
https://issues.jenkins-ci.org/browse/WEBSITE-406
https://issues.jenkins-ci.org/browse/JENKINS-59172

More info:  https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/
