### PR TITLE
SwarmSCMSource#getHeads uses swarm id instead of name for P4SCMHead

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/scm/SwarmScmSource.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/scm/SwarmScmSource.java
@@ -125,7 +125,7 @@ public class SwarmScmSource extends AbstractP4ScmSource {
 			// Get first Swarm path; it MUST include the Jenkinsfile
 			P4Path p4Path = branch.getPath();
 
-			P4SCMHead head = new P4SCMHead(branch.getId(), p4Path);
+			P4SCMHead head = new P4SCMHead(branch.getName(), p4Path);
 			list.add(head);
 		}
 


### PR DESCRIPTION
When SwarmSCMSource#getHeads() calls swarm for the branches incorrectly sets the swarm branch id instead of the branch name on P4SCMHead object. This causes the env. variable BRANCH_NAME to have an incorrect value since the swarm id is always lower-case from the API.

For example, calling Swarm API `http://swarm/api/v4/projects/my-application?fields=branches` returns 

`{
    "project": {
        "branches": [
            {
                "id": "dev-security-fixes",
                "name": "dev-Security-fixes",
                "workflow": null,
                "paths": [
                    "//Depot/my-application/dev-Security-fixes/..."
                ],
                "minimumUpVotes": null,
                "retainDefaultReviewers": false,
                "moderators": []
            }
        ]
    }
}`

In the API response we see `"id": "dev-security-fixes"` and `"name": "dev-Security-fixes"`. Ideally the BRANCH_NAME should contain 'dev-Security-fixes' and not the lower-case version.
