### PR TITLE
Add ContributorMetadataAction to SwarmScmSource to enable CHANGE_AUTHOR env variable in build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -85,11 +85,6 @@ public class ClientHelper extends ConnectionHelper {
 
 	private IClient iclient;
 
-	@Override
-	public IChangelistSummary getChangeSummary(long id) throws P4JavaException {
-		return super.getChangeSummary(id);
-	}
-
 	public ClientHelper(ItemGroup context, String credential, TaskListener listener, Workspace workspace) throws IOException {
 		super(context, credential, listener);
 		clientLogin(workspace);

--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -85,6 +85,11 @@ public class ClientHelper extends ConnectionHelper {
 
 	private IClient iclient;
 
+	@Override
+	public IChangelistSummary getChangeSummary(long id) throws P4JavaException {
+		return super.getChangeSummary(id);
+	}
+
 	public ClientHelper(ItemGroup context, String credential, TaskListener listener, Workspace workspace) throws IOException {
 		super(context, credential, listener);
 		clientLogin(workspace);

--- a/src/main/java/org/jenkinsci/plugins/p4/scm/P4ChangeRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/scm/P4ChangeRequestSCMHead.java
@@ -15,11 +15,17 @@ public class P4ChangeRequestSCMHead extends P4SCMHead implements ChangeRequestSC
 
 	private final SCMHead target;
 	private final String review;
+	private final String author;
 
 	P4ChangeRequestSCMHead(String name, String review, P4Path path, SCMHead target) {
+		this(name, review, path, target, null);
+	}
+
+	P4ChangeRequestSCMHead(String name, String review, P4Path path, SCMHead target, String author) {
 		super(name, path);
 		this.target = target;
 		this.review = review;
+		this.author = author;
 	}
 
 	@Override
@@ -29,6 +35,10 @@ public class P4ChangeRequestSCMHead extends P4SCMHead implements ChangeRequestSC
 
 	public String getReview() {
 		return review;
+	}
+
+	public String getAuthor() {
+		return author;
 	}
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/p4/scm/SwarmScmSource.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/scm/SwarmScmSource.java
@@ -7,6 +7,7 @@ import hudson.model.TaskListener;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.metadata.ContributorMetadataAction;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
 import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
@@ -97,13 +98,17 @@ public class SwarmScmSource extends AbstractP4ScmSource {
 	@Override
 	protected List<Action> retrieveActions(SCMHead head, SCMHeadEvent event, TaskListener listener) throws IOException, InterruptedException {
 		List<Action> actions = super.retrieveActions(head, event, listener);
-		if (head instanceof ChangeRequestSCMHead) {
-			ChangeRequestSCMHead scmHead = ((ChangeRequestSCMHead)head);
+		if (head instanceof P4ChangeRequestSCMHead) {
+			P4ChangeRequestSCMHead scmHead = ((P4ChangeRequestSCMHead)head);
 			try {
 				String changeUrl = getSwarm().getBaseUrl() + "/reviews/" + scmHead.getId();
 				actions.add(new ObjectMetadataAction(scmHead.getName(), null, changeUrl));
 			} catch (Exception e) {
 				listener.getLogger().println(e.getMessage());
+			}
+
+			if (scmHead.getAuthor() != null ) {
+				actions.add(new ContributorMetadataAction(scmHead.getAuthor(), scmHead.getAuthor(), null));
 			}
 		}
 		return actions;
@@ -126,7 +131,7 @@ public class SwarmScmSource extends AbstractP4ScmSource {
 					p4Path.setRevision(reviewID);
 
 					P4SCMHead target = new P4SCMHead(reviewID, p4Path);
-					P4ChangeRequestSCMHead tag = new P4ChangeRequestSCMHead(reviewID, reviewID, p4Path, target);
+					P4ChangeRequestSCMHead tag = new P4ChangeRequestSCMHead(reviewID, reviewID, p4Path, target, review.getAuthor());
 					list.add(tag);
 				}
 			}

--- a/src/main/java/org/jenkinsci/plugins/p4/swarmAPI/SwarmHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/swarmAPI/SwarmHelper.java
@@ -177,7 +177,7 @@ public class SwarmHelper {
 
 		Map<String, Object> query = new HashMap<>();
 		query.put("max", "10");
-		query.put("fields", "id,state,changes");
+		query.put("fields", "id,state,changes,author");
 		query.put("project", project);
 
 		HttpResponse<String> res = Unirest.get(url)
@@ -201,7 +201,7 @@ public class SwarmHelper {
 		String url = getApiUrl() + "/reviews/" + review;
 
 		Map<String, Object> query = new HashMap<>();
-		query.put("fields", "projects,changes,commits");
+		query.put("fields", "projects,changes,commits,author");
 
 		HttpResponse<String> res = Unirest.get(url)
 				.basicAuth(user, ticket)

--- a/src/main/java/org/jenkinsci/plugins/p4/swarmAPI/SwarmReviewAPI.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/swarmAPI/SwarmReviewAPI.java
@@ -22,11 +22,17 @@ public class SwarmReviewAPI {
 		private List<Long> changes;
 		private List<Long> commits;
 		private HashMap<String, List<String>> projects;
+		private String author;
 
-		public Review(List<Long> changes, List<Long> commits, HashMap<String, List<String>> projects) {
+		public Review(List<Long> changes, List<Long> commits, HashMap<String, List<String>> projects, String author) {
 			this.changes = changes;
 			this.commits = commits;
 			this.projects = projects;
+			this.author = author;
+		}
+
+		public String getAuthor() {
+			return author;
 		}
 
 		public List<Long> getChanges() {

--- a/src/main/java/org/jenkinsci/plugins/p4/swarmAPI/SwarmReviewsAPI.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/swarmAPI/SwarmReviewsAPI.java
@@ -9,6 +9,7 @@ public class SwarmReviewsAPI {
 	public static class Reviews {
 		private long id;
 		private List<Long> changes;
+		private String author;
 
 		public long getId() {
 			return id;
@@ -18,9 +19,14 @@ public class SwarmReviewsAPI {
 			return changes;
 		}
 
-		public Reviews(long id, List<Long> changes) {
+		public String getAuthor() {
+			return author;
+		}
+
+		public Reviews(long id, List<Long> changes, String author) {
 			this.id = id;
 			this.changes = changes;
+			this.author = author;
 		}
 	}
 

--- a/src/test/java/org/jenkinsci/plugins/p4/scm/PerforceSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/scm/PerforceSCMSourceTest.java
@@ -610,7 +610,7 @@ public class PerforceSCMSourceTest extends DefaultEnvironment {
 		changes.add(Long.parseLong(commit));
 		HashMap<String, List<String>> projects = new HashMap<>();
 		projects.put(project, Arrays.asList("Main"));
-		SwarmReviewAPI.Review mockReview = new SwarmReviewAPI.Review(changes, changes, projects);
+		SwarmReviewAPI.Review mockReview = new SwarmReviewAPI.Review(changes, changes, projects, "author");
 		when(mockSwarm.getSwarmReview(anyString())).thenReturn(new SwarmReviewAPI(mockReview));
 
 		// Build JSON Payload
@@ -682,7 +682,7 @@ public class PerforceSCMSourceTest extends DefaultEnvironment {
 		changes.add(Long.parseLong(commit));
 		HashMap<String, List<String>> projects = new HashMap<>();
 		projects.put(project, Arrays.asList("Main"));
-		SwarmReviewAPI.Review mockReview = new SwarmReviewAPI.Review(changes, changes, projects);
+		SwarmReviewAPI.Review mockReview = new SwarmReviewAPI.Review(changes, changes, projects, "author");
 		when(mockSwarm.getSwarmReview(anyString())).thenReturn(new SwarmReviewAPI(mockReview));
 
 		// Build JSON Payload
@@ -759,11 +759,11 @@ public class PerforceSCMSourceTest extends DefaultEnvironment {
 		changes.add(Long.parseLong(review));
 		HashMap<String, List<String>> projects = new HashMap<>();
 		projects.put(project, Arrays.asList("Main"));
-		SwarmReviewAPI.Review mockReview = new SwarmReviewAPI.Review(changes, changes, projects);
+		SwarmReviewAPI.Review mockReview = new SwarmReviewAPI.Review(changes, changes, projects, "author");
 		when(mockSwarm.getSwarmReview(anyString())).thenReturn(new SwarmReviewAPI(mockReview));
 
 		List<SwarmReviewsAPI.Reviews> mockReviewsList = new ArrayList<>();
-		SwarmReviewsAPI.Reviews mockReviews = new SwarmReviewsAPI.Reviews(Long.parseLong(review), changes);
+		SwarmReviewsAPI.Reviews mockReviews = new SwarmReviewsAPI.Reviews(Long.parseLong(review), changes, "author");
 		mockReviewsList.add(mockReviews);
 		when(mockSwarm.getActiveReviews(project)).thenReturn(mockReviewsList);
 


### PR DESCRIPTION
This change adds the author property to the query string of the /review Swarm API call and then adds the author information to P4ChangeRequestSCMHead. This allows the jenkins.branch.BranchNameContributor to add env variable CHANGE_AUTHOR to the build environment properties.