### PR TITLE
allow polling scm when populate options in job are set to pin to counter name in addition to changelist or label

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -1295,7 +1295,7 @@ public class ClientHelper extends ConnectionHelper {
 
 	/**
 	 * Fetches a list of changes needed to update the workspace to the specified
-	 * limit. The limit could be a Perforce change number or label.
+	 * limit. The limit could be a Perforce change number, label or counter.
 	 *
 	 * @param fromRefs    List of from revisions
 	 * @param changeLimit To Revision
@@ -1305,7 +1305,10 @@ public class ClientHelper extends ConnectionHelper {
 	public List<P4Ref> listHaveChanges(List<P4Ref> fromRefs, P4Ref changeLimit) throws Exception {
 
 		P4Ref from = getSingleChange(fromRefs);
-
+                // convert changeLimit from counter to change value
+                if (isCounter(changeLimit.toString())) {
+                  changeLimit = new P4ChangeRef(Long.parseLong(getCounter(changeLimit.toString())));
+                }
 		// return empty array, if from and changeLimit are equal, or Perforce will report a change
 		if (from.equals(changeLimit)) {
 			return new ArrayList<P4Ref>();


### PR DESCRIPTION
Existing code for populating workspace at  a "Pinned" change or label supports using a counter name,  see src/main/java/org/jenkinsci/plugins/p4/tasks/CheckoutTask.java line 95.   However the Polling code assumes the passed in "changeLimit" can be directly used in a "p4 changes @change1,@changeLimit" type of command, and this fails when a counter name is used.   The proposed change will check if the changeLimit is a counter, and if so substitute the counter value for the "changeLimit".   

Included new unit test for polling with a counter as the pinned change.

Without the fix, SCM polling with a pinned value of a counter named "my_counter_name" would result in 
P4: Task Exception: com.perforce.p4java.exception.RequestException: Invalid changelist/client/label/date '@my_counter_name'.

No further error checking is performed - it is assumed the end user would provide a valid p4 counter for their p4 populate configuration.

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

