### PR TITLE
Add support for controlling polling per change filter behavior with build parameter

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.p4.PerforceScm;
 
 def l = namespace(lib.JenkinsTagLib)
 
-["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
+["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
@@ -6,5 +6,6 @@ P4_USER.blurb=The Perforce username.
 P4_TICKET.blurb=A valid Perforce ticket (if the credential is valid).
 P4_REVIEW.blurb=The Swarm Review ID.
 P4_REVIEW_TYPE.blurb=The Swarm Review Type ('shelved' or 'committed').
+P4_INCREMENTAL.blurb=Build only oldest changelist returned by polling task.
 HUDSON_CHANGELOG_FILE.blurb=Location of the changelog file.
 JENKINSFILE_PATH.blurb=Location of the Jenkinsfile in depot.

--- a/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.p4.PerforceScm;
 
 def l = namespace(lib.JenkinsTagLib)
 
-["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
+["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
@@ -6,5 +6,6 @@ P4_USER.blurb=The Perforce username.
 P4_TICKET.blurb=A valid Perforce ticket (if the credential is valid).
 P4_REVIEW.blurb=The Swarm Review ID.
 P4_REVIEW_TYPE.blurb=The Swarm Review Type ('shelved' or 'committed').
+P4_INCREMENTAL.blurb=Build only oldest changelist returned by polling task.
 HUDSON_CHANGELOG_FILE.blurb=Location of the changelog file.
 JENKINSFILE_PATH.blurb=Location of the Jenkinsfile in depot.

--- a/src/main/resources/org/jenkinsci/plugins/p4/filters/FilterPerChangeImpl/help-perChange.html
+++ b/src/main/resources/org/jenkinsci/plugins/p4/filters/FilterPerChangeImpl/help-perChange.html
@@ -1,0 +1,6 @@
+<div>
+    <b>Polling per change</b>
+    <p>When enabled, only the one, oldest changelist returned by polling is built.</p>
+    <p>If <code>P4_INCREMENTAL</code> environment variable (or build parameter) is set to "false",
+        polling per change is ignored and all changelists are built.</p>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/p4/client/PollingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/PollingTest.java
@@ -145,6 +145,17 @@ public class PollingTest extends DefaultEnvironment {
 		build = project.scheduleBuild2(0, cause).get();
 		List<String> log = build.getLog(LOG_LIMIT);
 		assertTrue(log.contains("P4 Task: syncing files at change: 4"));
+
+		// JENKINS-66169: disable poll per change
+		List<ParameterValue> list2 = new ArrayList<>();
+		list2.add(new StringParameterValue("P4_INCREMENTAL", "false"));
+		Action actions2 = new SafeParametersAction(new ArrayList<ParameterValue>(), list2);
+
+		Cause.UserIdCause cause2 = new Cause.UserIdCause();
+		build = project.scheduleBuild2(0, cause2, actions2).get();
+		List<String> log2 = build.getLog(LOG_LIMIT);
+		assertEquals(Result.SUCCESS, build.getResult());
+		assertTrue(log2.contains("P4 Task: syncing files at change: 15"));
 	}
 
 	@Test


### PR DESCRIPTION
It has effect only when "Polling per change" filter is active.
When P4_INCREMENTAL environment variable exists and has string value "false",
"Polling per change" filter is ignored and all pending changelists are built.
If this parameter does not exist or has value "true", "Polling per
change" filter works normally.
This is to allow controlling of "Polling per change" behavior in
FreeStyleProject jobs.

It is implementation of JENKINS-66169.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

