### PR TITLE
Add support for Windows linebreaks in filters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/filters/FilterPatternListImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/filters/FilterPatternListImpl.java
@@ -46,7 +46,7 @@ public class FilterPatternListImpl extends Filter implements Serializable {
 			caseFlag = Pattern.CASE_INSENSITIVE;
 		}
 		
-		for (String line : patternText.split("\n")) {
+		for (String line : patternText.split("\\R")) {
 			// Try compiling each line into patterns. If we can't compile a line, skip it and log.
 			try {
 				patternList.add(Pattern.compile(line, caseFlag));
@@ -75,7 +75,7 @@ public class FilterPatternListImpl extends Filter implements Serializable {
 			
 			int lineNumber = 1;
 			try {
-				for (String line: value.split("\n")) {
+				for (String line: value.split("\\R")) {
 					Pattern.compile(line);
 					lineNumber++;
 				}

--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/PollTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/PollTask.java
@@ -151,10 +151,11 @@ public class PollTask extends AbstractTask implements FileCallable<List<P4Ref>>,
 				List<IFileSpec> included = new ArrayList<IFileSpec>();
 
 				String viewMask = ((FilterViewMaskImpl) f).getViewMask();
+				String[] maskPaths = viewMask.split("\\R");
 				for (IFileSpec s : files) {
 					boolean isFileInViewMask = false;
 					String p = s.getDepotPathString();
-					for (String maskPath : viewMask.split("\n")) {
+					for (String maskPath : maskPaths) {
 						if (p.startsWith(maskPath)) {
 							isFileInViewMask = true;
 						}


### PR DESCRIPTION
Filters are specified as multi-line strings, but only support Unix
linebreaks (\n). This extends them to also support other platforms'
linebreaks, using the Java8 \R regex matcher for "any Unicode linebreak
sequence".

This is particularly useful if you have your Jenkins controller on a
Windows machine and you're specifying view filters as multiline groovy
strings. E.g.

```groovy
filter: [viewFilter('''//depot/path1
//depot/path2''')]
```

In this case, only the last path listed would be considered correctly,
because it would match the paths using
`p.startswith("//depot/path1\r")`, which would never be true.