### PR TITLE
Force sync and populate have list on P4_CLEANWORKSPACE

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
@@ -15,6 +15,7 @@ import hudson.matrix.MatrixProject;
 import hudson.model.AbstractProject;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Item;
+import hudson.model.FreeStyleBuild;
 import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
@@ -54,6 +55,7 @@ import org.jenkinsci.plugins.p4.filters.FilterLatestChangeImpl;
 import org.jenkinsci.plugins.p4.filters.FilterPerChangeImpl;
 import org.jenkinsci.plugins.p4.matrix.MatrixOptions;
 import org.jenkinsci.plugins.p4.populate.Populate;
+import org.jenkinsci.plugins.p4.populate.SyncOnlyImpl;
 import org.jenkinsci.plugins.p4.review.P4Review;
 import org.jenkinsci.plugins.p4.review.ReviewProp;
 import org.jenkinsci.plugins.p4.scm.AbstractP4ScmSource;
@@ -525,8 +527,33 @@ public class PerforceScm extends SCM {
 		PrintStream log = listener.getLogger();
 		boolean success = true;
 
+		CheckoutTask task = null;
+
+		if (run instanceof FreeStyleBuild) {
+			String p4CleanWorkspace;
+			EnvVars envVars = run.getEnvironment(listener);
+			p4CleanWorkspace = envVars.getOrDefault("P4CLEANWORKSPACE", "false");
+
+			if (p4CleanWorkspace.equals("true") && populate instanceof SyncOnlyImpl) {
+				listener.getLogger().println("P4: Wiping workspace...");
+				buildWorkspace.deleteRecursive();
+
+				Populate populateWithForceSync = new SyncOnlyImpl(
+						((SyncOnlyImpl) populate).isRevert(),
+						true,
+						true,
+						populate.isModtime(),
+						populate.isQuiet(),
+						populate.getPin(),
+						populate.getParallel());
+				task = new CheckoutTask(credential, run, listener, populateWithForceSync);
+			}
+		}
+
 		// Create task
-		CheckoutTask task = new CheckoutTask(credential, run, listener, populate);
+		if (task == null) {
+			task = new CheckoutTask(credential, run, listener, populate);
+		}
 
 		// Update credential tracking
 		try {

--- a/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.p4.PerforceScm;
 
 def l = namespace(lib.JenkinsTagLib)
 
-["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
+["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","P4_CLEANWORKSPACE","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
@@ -7,5 +7,6 @@ P4_TICKET.blurb=A valid Perforce ticket (if the credential is valid).
 P4_REVIEW.blurb=The Swarm Review ID.
 P4_REVIEW_TYPE.blurb=The Swarm Review Type ('shelved' or 'committed').
 P4_INCREMENTAL.blurb=Build only oldest changelist returned by polling task.
+P4_CLEANWORKSPACE.blurb="If true, force sync and update have list"
 HUDSON_CHANGELOG_FILE.blurb=Location of the changelog file.
 JENKINSFILE_PATH.blurb=Location of the Jenkinsfile in depot.

--- a/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.p4.PerforceScm;
 
 def l = namespace(lib.JenkinsTagLib)
 
-["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
+["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","P4_CLEANWORKSPACE","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
@@ -7,5 +7,6 @@ P4_TICKET.blurb=A valid Perforce ticket (if the credential is valid).
 P4_REVIEW.blurb=The Swarm Review ID.
 P4_REVIEW_TYPE.blurb=The Swarm Review Type ('shelved' or 'committed').
 P4_INCREMENTAL.blurb=Build only oldest changelist returned by polling task.
+P4_CLEANWORKSPACE.blurb="If true, force sync and update have list"
 HUDSON_CHANGELOG_FILE.blurb=Location of the changelog file.
 JENKINSFILE_PATH.blurb=Location of the Jenkinsfile in depot.


### PR DESCRIPTION
When using SyncOnlyImpl, setting P4_CLEANWORKSPACE variable can
be used to request wiping workspace and doing fresh sync when
needed. When P4_CLEANWORKSPACE is set and "true", build workspace
is cleaned and then force sync and update have list is requested.
This behaviour applies to FreeStyleBuild only.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue