### PR TITLE
Force sync and populate have list on P4_CLEANWORKSPACE

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 ## Release notes
 
+### Release 1.12.4 (major features/fixes)
+
+[@28770](https://swarm.workshop.perforce.com/changes/28770) - Check Item is PerforceScm.DescriptorImpl onChange event. JENKINS-68378
+
+
 ### Release 1.12.3 (major features/fixes)
 
 [@28755](https://swarm.workshop.perforce.com/changes/28755) - Updating P4Java to 2021.2.2278127 JENKINS-67631 JENKINS-68006 JENKINS-67936 JENKINS-64739 JENKINS-54500 JENKINS-27877

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 ## Release notes
 
+### Release 1.12.3 (major features/fixes)
+
+[@28755](https://swarm.workshop.perforce.com/changes/28755) - Updating P4Java to 2021.2.2278127 JENKINS-67631 JENKINS-68006 JENKINS-67936 JENKINS-64739 JENKINS-54500 JENKINS-27877
+
+[@28735](https://swarm.workshop.perforce.com/changes/28735) - Merge pull request #142 from skumar7322/branchIndexing. Branch indexing occurring for every multibranch job JENKINS-64946
+
+[@28728](https://swarm.workshop.perforce.com/changes/28728) - Merge pull request #141 from joel-f-brown/master. User session cache logging level changed to finer/finest JENKINS-68006
+
+
 ### Release 1.12.2 (major features/fixes)
 
 [@28555](https://swarm.workshop.perforce.com/changes/28555) - Update p4java patch version 2021.2.2240592

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.4</version>
+  <version>1.12.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>p4-1.12.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.3-SNAPSHOT</version>
+  <version>1.12.3</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>p4-1.12.3</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.3</version>
+  <version>1.12.4-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>p4-1.12.3</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.perforce</groupId>
       <artifactId>p4java</artifactId>
-      <version>2021.2.2240592</version>
+      <version>2021.2.2278127</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.4-SNAPSHOT</version>
+  <version>1.12.4</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>p4-1.12.4</tag>
   </scm>
 
   <developers>

--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeEntry.java
@@ -294,6 +294,10 @@ public class P4ChangeEntry extends ChangeLogSet.Entry {
 		affectedFiles.add(file);
 	}
 
+	public void setFileLimit(boolean value) {
+		fileLimit = value;
+	}
+
 	public boolean isFileLimit() {
 		return fileLimit;
 	}

--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeParser.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeParser.java
@@ -225,6 +225,12 @@ public class P4ChangeParser extends ChangeLogParser {
 							return;
 						}
 
+						if (qName.equalsIgnoreCase("fileLimit")) {
+							entry.setFileLimit(elementText.equals("true"));
+							text.setLength(0);
+							return;
+						}
+
 						if (qName.equalsIgnoreCase("msg")) {
 							entry.setMsg(elementText);
 							text.setLength(0);

--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeSet.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeSet.java
@@ -74,6 +74,8 @@ public class P4ChangeSet extends ChangeLogSet<P4ChangeEntry> {
 
 					stream.println("\t\t<shelved>" + cl.isShelved() + "</shelved>");
 
+					stream.println("\t\t<fileLimit>" + cl.isFileLimit() + "</fileLimit>");
+
 					stream.println("\t\t<files>");
 					Collection<P4AffectedFile> files = cl.getAffectedFiles();
 					if (files != null) {

--- a/src/main/java/org/jenkinsci/plugins/p4/client/SessionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/SessionHelper.java
@@ -147,7 +147,7 @@ public class SessionHelper extends CredentialsHelper {
 				if (sessionEnabled && isLogin()) {
 					if (connection.getAuthTicket() == null) {
 						SessionEntry entry = loginCache.get(sessionId);
-						logger.info("Setting connection's ticket from cache: " + entry.getTicket());
+						logger.finer("Setting connection's ticket from session cache (" + sessionId + ")");
 						connection.setAuthTicket(entry.getTicket());
 					}
 					return true;
@@ -298,22 +298,23 @@ public class SessionHelper extends CredentialsHelper {
 
 	private boolean isLogin() throws Exception {
 		String user = connection.getUserName();
-		if (sessionEnabled && loginCache.containsKey(sessionId)) {
-			SessionEntry entry = loginCache.get(sessionId);
-			long expire = entry.getExpire();
-			long remain = expire - System.currentTimeMillis() - sessionLife;
-			if (remain > 0) {
-				logger.info("Found session entry for: " + sessionId + "(" + entry + ")");
-				return true;
+		if (sessionEnabled) {
+			if (loginCache.containsKey(sessionId)) {
+				SessionEntry entry = loginCache.get(sessionId);
+				long expire = entry.getExpire();
+				long remain = expire - System.currentTimeMillis() - sessionLife;
+				if (remain > 0) {
+					logger.finest("Found session entry for: " + sessionId + " (expires " + entry.getExpire() + ")");
+					return true;
+				} else {
+					logger.finest("Removing session entry for: " + sessionId );
+					loginCache.remove(sessionId);
+				}
 			} else {
-				logger.info("Removing session entry for: " + sessionId + "(" + entry + ")");
-				loginCache.remove(sessionId);
+				logger.finest("No entry in session for: " + sessionId);
 			}
 		}
 
-		if (sessionEnabled) {
-			logger.info("No entry in session for: " + sessionId );
-		}
 		List<Map<String, Object>> resultMaps = connection.execMapCmdList(CmdSpec.LOGIN, new String[]{"-s"}, null);
 		String ticket = connection.getAuthTicket();
 

--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/TaggingTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/TaggingTask.java
@@ -65,6 +65,7 @@ public class TaggingTask extends AbstractTask implements FileCallable<Boolean>,
 				String left = entry.getLeft();
 				LabelMapping lblMap = new LabelMapping();
 				lblMap.setLeft("\""+left+"\"");
+				lblMap.setType(entry.getType());  // Make sure type is carried forward
 				viewMapping.addEntry(lblMap);
 			}
 			label.setViewMapping(viewMapping);

--- a/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.p4.PerforceScm;
 
 def l = namespace(lib.JenkinsTagLib)
 
-["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
+["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","P4_CLEANWORKSPACE","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
@@ -7,5 +7,6 @@ P4_TICKET.blurb=A valid Perforce ticket (if the credential is valid).
 P4_REVIEW.blurb=The Swarm Review ID.
 P4_REVIEW_TYPE.blurb=The Swarm Review Type ('shelved' or 'committed').
 P4_INCREMENTAL.blurb=Build only oldest changelist returned by polling task.
+P4_CLEANWORKSPACE.blurb="If true, force sync and update have list"
 HUDSON_CHANGELOG_FILE.blurb=Location of the changelog file.
 JENKINSFILE_PATH.blurb=Location of the Jenkinsfile in depot.

--- a/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.p4.PerforceScm;
 
 def l = namespace(lib.JenkinsTagLib)
 
-["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
+["P4_CHANGELIST","P4_CLIENT","P4_PORT","P4_ROOT","P4_USER","P4_TICKET","P4_REVIEW","P4_REVIEW_TYPE","P4_INCREMENTAL","P4_CLEANWORKSPACE","HUDSON_CHANGELOG_FILE","JENKINSFILE_PATH"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
@@ -7,5 +7,6 @@ P4_TICKET.blurb=A valid Perforce ticket (if the credential is valid).
 P4_REVIEW.blurb=The Swarm Review ID.
 P4_REVIEW_TYPE.blurb=The Swarm Review Type ('shelved' or 'committed').
 P4_INCREMENTAL.blurb=Build only oldest changelist returned by polling task.
+P4_CLEANWORKSPACE.blurb="If true, force sync and update have list"
 HUDSON_CHANGELOG_FILE.blurb=Location of the changelog file.
 JENKINSFILE_PATH.blurb=Location of the Jenkinsfile in depot.

--- a/src/test/java/org/jenkinsci/plugins/p4/DefaultEnvironment.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/DefaultEnvironment.java
@@ -236,7 +236,7 @@ abstract public class DefaultEnvironment {
 	}
 
 	protected boolean waitForBuild(WorkflowJob job, int buildNumber) throws InterruptedException {
-		return waitForBuild(job, buildNumber, 50, 200L);
+		return waitForBuild(job, buildNumber, 170, 200L);
 	}
 
 	protected boolean waitForBuild(WorkflowJob job, int buildNumber, final int retry, long delay) throws InterruptedException {


### PR DESCRIPTION
When using SyncOnlyImpl, setting P4_CLEANWORKSPACE variable can
be used to request wiping workspace and doing fresh sync when
needed. When P4_CLEANWORKSPACE is set and "true", build workspace
is cleaned and then force sync and update have list is requested.
This implements https://issues.jenkins.io/browse/JENKINS-66603

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

