### PR TITLE
[JENKINS-66648] Replace 'now' label with the P4ChangeRef for the current head

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/CheckoutTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/CheckoutTask.java
@@ -107,6 +107,10 @@ public class CheckoutTask extends AbstractTask implements FileCallable<Boolean>,
 						// no change number in counter
 					}
 				}
+				// JENKINS-66648
+				if (label.equals("now")) {
+					buildChange = new P4ChangeRef(head);
+				}
 			} else {
 				// if change is bigger than head, use head
 				if (buildChange.getChange() > head) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
When initializing a `CheckoutTask` with a `P4LabelRef=now`, replace it with a `P4ChangeRef=head`.

See: https://issues.jenkins.io/browse/JENKINS-66648.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
