### PR TITLE
Fix bug where exclude paths are turned into include paths

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 ## Release notes
 
+### Release 1.12.0 (major features/fixes)
+
+[@28510](https://swarm.workshop.perforce.com/changes/28510) - Update P4Java 2021.2.2234376
+
+[@28508](https://swarm.workshop.perforce.com/changes/28508) - Cache P4TICKET in session. Session cache now keyed on Credential ID and stores: User, Expiry time and Ticket. JENKINS-60141
+
+
 ### Release 1.11.6 (major features/fixes)
 
 [@28022](https://swarm.workshop.perforce.com/changes/28022) - Merge pull request #134 from stuartrowe/JENKINS-66648  [JENKINS-66648] Replace 'now' label with the P4ChangeRef for the current head

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 ## Release notes
 
+### Release 1.12.1 (major features/fixes)
+
+[@28528](https://swarm.workshop.perforce.com/changes/28528) - Merge pull request #136 from NotMyFault/chore/master/prep-for-icon-removal-from-core Preparation for core removing sunset icons: https://github.com/jenkinsci/jenkins/pull/5778/
+
+[@28526](https://swarm.workshop.perforce.com/changes/28526) - Merge pull request #137 from joel-f-brown/master If Credential ID exists in session cache, set the connection's Ticket
+
+[@28525](https://swarm.workshop.perforce.com/changes/28525) - Use ConcurrentHashMap for thread safety.
+
+
 ### Release 1.12.0 (major features/fixes)
 
 [@28510](https://swarm.workshop.perforce.com/changes/28510) - Update P4Java 2021.2.2234376

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 ## Release notes
 
+### Release 1.12.2 (major features/fixes)
+
+[@28555](https://swarm.workshop.perforce.com/changes/28555) - Update p4java patch version 2021.2.2240592
+
+
 ### Release 1.12.1 (major features/fixes)
 
 [@28528](https://swarm.workshop.perforce.com/changes/28528) - Merge pull request #136 from NotMyFault/chore/master/prep-for-icon-removal-from-core Preparation for core removing sunset icons: https://github.com/jenkinsci/jenkins/pull/5778/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 ## Release notes
 
+### Release 1.12.4 (major features/fixes)
+
+[@28770](https://swarm.workshop.perforce.com/changes/28770) - Check Item is PerforceScm.DescriptorImpl onChange event. JENKINS-68378
+
+
 ### Release 1.12.3 (major features/fixes)
 
 [@28755](https://swarm.workshop.perforce.com/changes/28755) - Updating P4Java to 2021.2.2278127 JENKINS-67631 JENKINS-68006 JENKINS-67936 JENKINS-64739 JENKINS-54500 JENKINS-27877

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 ## Release notes
 
+### Release 1.12.3 (major features/fixes)
+
+[@28755](https://swarm.workshop.perforce.com/changes/28755) - Updating P4Java to 2021.2.2278127 JENKINS-67631 JENKINS-68006 JENKINS-67936 JENKINS-64739 JENKINS-54500 JENKINS-27877
+
+[@28735](https://swarm.workshop.perforce.com/changes/28735) - Merge pull request #142 from skumar7322/branchIndexing. Branch indexing occurring for every multibranch job JENKINS-64946
+
+[@28728](https://swarm.workshop.perforce.com/changes/28728) - Merge pull request #141 from joel-f-brown/master. User session cache logging level changed to finer/finest JENKINS-68006
+
+
 ### Release 1.12.2 (major features/fixes)
 
 [@28555](https://swarm.workshop.perforce.com/changes/28555) - Update p4java patch version 2021.2.2240592

--- a/docs/P4GROOVY.md
+++ b/docs/P4GROOVY.md
@@ -4,7 +4,7 @@ _Online documentation for [P4Groovy](https://www.perforce.com/manuals/jenkins/Co
 
 ## Introduction
 
-P4Groovy is a Groovy interface to P4Java that allows you to write Perforce commands in the pipleline DSL.
+P4Groovy is a Groovy interface to P4Java that allows you to write Perforce commands in the pipeline DSL.
 
 ## Setup
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.0</version>
+  <version>1.12.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>p4-1.12.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.4</version>
+  <version>1.12.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>p4-1.12.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.11.7-SNAPSHOT</version>
+  <version>1.12.0</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>p4-1.12.0</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.3-SNAPSHOT</version>
+  <version>1.12.3</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>p4-1.12.3</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.3</version>
+  <version>1.12.4-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>p4-1.12.3</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.1</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>p4-1.12.1</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.perforce</groupId>
       <artifactId>p4java</artifactId>
-      <version>2021.2.2234376</version>
+      <version>2021.2.2240592</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.perforce</groupId>
       <artifactId>p4java</artifactId>
-      <version>2021.2.2240592</version>
+      <version>2021.2.2278127</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.perforce</groupId>
       <artifactId>p4java</artifactId>
-      <version>2021.1.2163843</version>
+      <version>2021.2.2234376</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.2</version>
+  <version>1.12.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>p4-1.12.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.2-SNAPSHOT</version>
+  <version>1.12.2</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>p4-1.12.2</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.1</version>
+  <version>1.12.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>p4-1.12.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>p4</artifactId>
-  <version>1.12.4-SNAPSHOT</version>
+  <version>1.12.4</version>
   <packaging>hpi</packaging>
 
   <name>P4 Plugin</name>
@@ -25,7 +25,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>p4-1.12.4</tag>
   </scm>
 
   <developers>

--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeEntry.java
@@ -294,6 +294,10 @@ public class P4ChangeEntry extends ChangeLogSet.Entry {
 		affectedFiles.add(file);
 	}
 
+	public void setFileLimit(boolean value) {
+		fileLimit = value;
+	}
+
 	public boolean isFileLimit() {
 		return fileLimit;
 	}

--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeParser.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeParser.java
@@ -225,6 +225,12 @@ public class P4ChangeParser extends ChangeLogParser {
 							return;
 						}
 
+						if (qName.equalsIgnoreCase("fileLimit")) {
+							entry.setFileLimit(elementText.equals("true"));
+							text.setLength(0);
+							return;
+						}
+
 						if (qName.equalsIgnoreCase("msg")) {
 							entry.setMsg(elementText);
 							text.setLength(0);

--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeSet.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeSet.java
@@ -74,6 +74,8 @@ public class P4ChangeSet extends ChangeLogSet<P4ChangeEntry> {
 
 					stream.println("\t\t<shelved>" + cl.isShelved() + "</shelved>");
 
+					stream.println("\t\t<fileLimit>" + cl.isFileLimit() + "</fileLimit>");
+
 					stream.println("\t\t<files>");
 					Collection<P4AffectedFile> files = cl.getAffectedFiles();
 					if (files != null) {

--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -129,7 +129,7 @@ public class ClientHelper extends ConnectionHelper {
 				login();
 				iclient = workspace.setClient(getConnection(), user);
 			} catch (RequestException | AccessException e) {
-				ConnectionHelper.invalidateUser(user);
+				invalidateSession();
 				login();
 				iclient = workspace.setClient(getConnection(), user);
 			}

--- a/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
@@ -11,15 +11,11 @@ import com.perforce.p4java.core.IStreamSummary;
 import com.perforce.p4java.core.IUser;
 import com.perforce.p4java.core.file.FileSpecBuilder;
 import com.perforce.p4java.core.file.IFileSpec;
-import com.perforce.p4java.exception.AccessException;
-import com.perforce.p4java.exception.ConnectionException;
 import com.perforce.p4java.exception.P4JavaException;
 import com.perforce.p4java.exception.RequestException;
 import com.perforce.p4java.graph.ICommit;
 import com.perforce.p4java.impl.generic.core.Label;
 import com.perforce.p4java.impl.generic.core.file.FileSpec;
-import com.perforce.p4java.impl.mapbased.server.Server;
-import com.perforce.p4java.impl.mapbased.server.cmd.ResultMapParser;
 import com.perforce.p4java.option.server.CounterOptions;
 import com.perforce.p4java.option.server.DeleteClientOptions;
 import com.perforce.p4java.option.server.GetChangelistsOptions;
@@ -31,39 +27,24 @@ import com.perforce.p4java.option.server.GetStreamsOptions;
 import com.perforce.p4java.option.server.GraphCommitLogOptions;
 import com.perforce.p4java.option.server.ReposOptions;
 import com.perforce.p4java.server.CmdSpec;
-import com.perforce.p4java.server.IOptionsServer;
-import com.perforce.p4java.server.callback.ICommandCallback;
-import com.perforce.p4java.server.callback.IProgressCallback;
-import hudson.AbortException;
-import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.LogTaskListener;
-import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.p4.PerforceScm;
 import org.jenkinsci.plugins.p4.changes.P4GraphRef;
 import org.jenkinsci.plugins.p4.changes.P4LabelRef;
 import org.jenkinsci.plugins.p4.changes.P4Ref;
-import org.jenkinsci.plugins.p4.console.P4Logging;
-import org.jenkinsci.plugins.p4.console.P4Progress;
 import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-
-import static com.perforce.p4java.common.base.ObjectUtils.nonNull;
 
 public class ConnectionHelper extends SessionHelper implements AutoCloseable {
 

--- a/src/main/java/org/jenkinsci/plugins/p4/client/NavigateHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/NavigateHelper.java
@@ -91,7 +91,7 @@ public class NavigateHelper implements Closeable {
 		} catch (RequestException | AccessException e) {
 			String user = p4.getUserName();
 			logger.info("Removing loginCache entry for: " + user);
-			ConnectionHelper.invalidateUser(user);
+			ConnectionHelper.invalidateSession(user);
 		} catch (P4JavaException e) {
 			logger.warning(e.getMessage());
 		}

--- a/src/main/java/org/jenkinsci/plugins/p4/client/SessionEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/SessionEntry.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.p4.client;
+
+public class SessionEntry {
+
+	private final String user;
+	private final String ticket;
+	private final long expire;
+
+	public SessionEntry(String user, String ticket, long expire) {
+		this.user = user;
+		this.ticket = ticket;
+		this.expire = expire;
+	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public String getTicket() {
+		return ticket;
+	}
+
+	public long getExpire() {
+		return expire;
+	}
+
+	@Override
+	public String toString() {
+		return user + ":" + expire;
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/p4/client/SessionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/SessionHelper.java
@@ -147,7 +147,7 @@ public class SessionHelper extends CredentialsHelper {
 				if (sessionEnabled && isLogin()) {
 					if (connection.getAuthTicket() == null) {
 						SessionEntry entry = loginCache.get(sessionId);
-						logger.info("Setting connection's ticket from cache: " + entry.getTicket());
+						logger.finer("Setting connection's ticket from session cache (" + sessionId + ")");
 						connection.setAuthTicket(entry.getTicket());
 					}
 					return true;
@@ -298,22 +298,23 @@ public class SessionHelper extends CredentialsHelper {
 
 	private boolean isLogin() throws Exception {
 		String user = connection.getUserName();
-		if (sessionEnabled && loginCache.containsKey(sessionId)) {
-			SessionEntry entry = loginCache.get(sessionId);
-			long expire = entry.getExpire();
-			long remain = expire - System.currentTimeMillis() - sessionLife;
-			if (remain > 0) {
-				logger.info("Found session entry for: " + sessionId + "(" + entry + ")");
-				return true;
+		if (sessionEnabled) {
+			if (loginCache.containsKey(sessionId)) {
+				SessionEntry entry = loginCache.get(sessionId);
+				long expire = entry.getExpire();
+				long remain = expire - System.currentTimeMillis() - sessionLife;
+				if (remain > 0) {
+					logger.finest("Found session entry for: " + sessionId + " (expires " + entry.getExpire() + ")");
+					return true;
+				} else {
+					logger.finest("Removing session entry for: " + sessionId );
+					loginCache.remove(sessionId);
+				}
 			} else {
-				logger.info("Removing session entry for: " + sessionId + "(" + entry + ")");
-				loginCache.remove(sessionId);
+				logger.finest("No entry in session for: " + sessionId);
 			}
 		}
 
-		if (sessionEnabled) {
-			logger.info("No entry in session for: " + sessionId );
-		}
 		List<Map<String, Object>> resultMaps = connection.execMapCmdList(CmdSpec.LOGIN, new String[]{"-s"}, null);
 		String ticket = connection.getAuthTicket();
 

--- a/src/main/java/org/jenkinsci/plugins/p4/client/SessionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/SessionHelper.java
@@ -20,16 +20,15 @@ import org.jenkinsci.plugins.p4.console.P4Progress;
 import org.jenkinsci.plugins.p4.credentials.P4BaseCredentials;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-
-import static com.perforce.p4java.common.base.ObjectUtils.nonNull;
 
 public class SessionHelper extends CredentialsHelper {
 
@@ -44,7 +43,7 @@ public class SessionHelper extends CredentialsHelper {
 	private IOptionsServer connection;
 	private boolean abort = false;
 
-	private static Map<String, SessionEntry> loginCache = new HashMap<>();
+	private static ConcurrentMap<String, SessionEntry> loginCache = new ConcurrentHashMap<>();
 
 	public SessionHelper(P4BaseCredentials credential, TaskListener listener) throws IOException {
 		super(credential, listener);
@@ -312,7 +311,7 @@ public class SessionHelper extends CredentialsHelper {
 		List<Map<String, Object>> resultMaps = connection.execMapCmdList(CmdSpec.LOGIN, new String[]{"-s"}, null);
 		String ticket = connection.getAuthTicket();
 
-		if (nonNull(resultMaps) && !resultMaps.isEmpty()) {
+		if (resultMaps != null && !resultMaps.isEmpty()) {
 			for (Map<String, Object> map : resultMaps) {
 				String status = ResultMapParser.getInfoStr(map);
 				if (status == null) {

--- a/src/main/java/org/jenkinsci/plugins/p4/tagging/TagAction.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tagging/TagAction.java
@@ -216,7 +216,7 @@ public class TagAction extends AbstractScmTagAction {
 			return p4ticket;
 		}
 
-		logger.finer("TagAction:getTicket()");
+		logger.info("TagAction:getTicket()");
 		P4BaseCredentials auth = ConnectionHelper.findCredential(credential, getRun());
 
 		try (ConnectionHelper p4 = new ConnectionHelper(auth, null)) {

--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/TaggingTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/TaggingTask.java
@@ -65,6 +65,7 @@ public class TaggingTask extends AbstractTask implements FileCallable<Boolean>,
 				String left = entry.getLeft();
 				LabelMapping lblMap = new LabelMapping();
 				lblMap.setLeft("\""+left+"\"");
+				lblMap.setType(entry.getType());  // Make sure type is carried forward
 				viewMapping.addEntry(lblMap);
 			}
 			label.setViewMapping(viewMapping);

--- a/src/main/resources/org/jenkinsci/plugins/p4/review/ReviewAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/review/ReviewAction/index.jelly
@@ -1,10 +1,10 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
 
     <l:layout title="${%Build With Parameters}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="../" title="${%Back to Project}"/>
+                <l:task icon="icon-up icon-md" href="../" title="${%Back to Project}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>

--- a/src/main/resources/org/jenkinsci/plugins/p4/trigger/P4Hook/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/trigger/P4Hook/index.jelly
@@ -1,10 +1,10 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
 
     <l:layout title="${%Trigger Perforce Jobs}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="../" title="${%Back to Project}"/>
+                <l:task icon="icon-up icon-md" href="../" title="${%Back to Project}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>

--- a/src/test/java/org/jenkinsci/plugins/p4/DefaultEnvironment.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/DefaultEnvironment.java
@@ -236,7 +236,7 @@ abstract public class DefaultEnvironment {
 	}
 
 	protected boolean waitForBuild(WorkflowJob job, int buildNumber) throws InterruptedException {
-		return waitForBuild(job, buildNumber, 50, 200L);
+		return waitForBuild(job, buildNumber, 170, 200L);
 	}
 
 	protected boolean waitForBuild(WorkflowJob job, int buildNumber, final int retry, long delay) throws InterruptedException {

--- a/src/test/java/org/jenkinsci/plugins/p4/scm/P4SCMFileSystemTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/scm/P4SCMFileSystemTest.java
@@ -65,8 +65,8 @@ public class P4SCMFileSystemTest extends DefaultEnvironment {
 		SCMSourceOwner owner = new WorkflowMultiBranchProject(Jenkins.getInstance(), "autoComplete");
 
 		// Clear login cache then initialise default connection
-		ConnectionHelper.invalidateUser("jenkins");
-		new ConnectionHelper(owner, CREDENTIAL, null);
+		ConnectionHelper p4 = new ConnectionHelper(owner, CREDENTIAL, null);
+		p4.invalidateSession();
 
 		NavigateHelper nav = new NavigateHelper(5);
 


### PR DESCRIPTION
The bug is in the p4tag pipeline function.

The object creates the new label mapping based on the string of the client mapping, but the exclude marker "-" is not part of the string.  The type needs to be restored before adding the entry to the label view mapping.  One line change to call setTag on the new entry.

<!-- Please describe your pull request here. -->

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
