### PR TITLE
chore: Prepare for sunset icon removal from core

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/p4/review/ReviewAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/review/ReviewAction/index.jelly
@@ -1,10 +1,10 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
 
     <l:layout title="${%Build With Parameters}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="../" title="${%Back to Project}"/>
+                <l:task icon="icon-up icon-md" href="../" title="${%Back to Project}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>

--- a/src/main/resources/org/jenkinsci/plugins/p4/trigger/P4Hook/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/p4/trigger/P4Hook/index.jelly
@@ -1,10 +1,10 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
 
     <l:layout title="${%Trigger Perforce Jobs}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="../" title="${%Back to Project}"/>
+                <l:task icon="icon-up icon-md" href="../" title="${%Back to Project}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>


### PR DESCRIPTION
Preparation for core removing sunset icons: `https://github.com/jenkinsci/jenkins/pull/5778/`

@p4paul Would be nice if you can also trigger a release after merging this PR.
Thanks in advance!