### PR TITLE
Always trigger a build if there's no previous one

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
@@ -435,10 +435,10 @@ public class PerforceScm extends SCM {
 		// Cleanup Perforce Client
 		cleanupPerforceClient(lastRun, buildWorkspace, listener, ws);
 
-		// Build if changes are found or report NO_CHANGE
+		// Build if changes are found or we can't determine the previous built change, or report NO_CHANGE
 		if (changes == null) {
 			listener.getLogger().println("P4: Polling error; no previous change.");
-			return PollingResult.NO_CHANGES;
+			return PollingResult.BUILD_NOW;
 		} else if (changes.isEmpty()) {
 			listener.getLogger().println("P4: Polling no changes found.");
 			return PollingResult.NO_CHANGES;


### PR DESCRIPTION
When we can't determine the previously built change, always trigger a
build. Otherwise, Perforce triggers and Perforce polling will never
trigger a build until a manual build has been run.

It also seems that if a build fails before recording a last synced
change, it will "revert" to this "unbuilt" state, so further triggers
will not build the job.

This also seems to have been the intended functionality, if you look in 
[PerforceScm.java on line 495](https://github.com/jenkinsci/p4-plugin/blob/master/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java#L495) it says `Calculate last change, build if null`