### PR TITLE
Persist `fileLimit` when serializing a changeset

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeEntry.java
@@ -294,6 +294,10 @@ public class P4ChangeEntry extends ChangeLogSet.Entry {
 		affectedFiles.add(file);
 	}
 
+	public void setFileLimit(boolean value) {
+		fileLimit = value;
+	}
+
 	public boolean isFileLimit() {
 		return fileLimit;
 	}

--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeParser.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeParser.java
@@ -225,6 +225,12 @@ public class P4ChangeParser extends ChangeLogParser {
 							return;
 						}
 
+						if (qName.equalsIgnoreCase("fileLimit")) {
+							entry.setFileLimit(elementText.equals("true"));
+							text.setLength(0);
+							return;
+						}
+
 						if (qName.equalsIgnoreCase("msg")) {
 							entry.setMsg(elementText);
 							text.setLength(0);

--- a/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeSet.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/changes/P4ChangeSet.java
@@ -74,6 +74,8 @@ public class P4ChangeSet extends ChangeLogSet<P4ChangeEntry> {
 
 					stream.println("\t\t<shelved>" + cl.isShelved() + "</shelved>");
 
+					stream.println("\t\t<fileLimit>" + cl.isFileLimit() + "</fileLimit>");
+
 					stream.println("\t\t<files>");
 					Collection<P4AffectedFile> files = cl.getAffectedFiles();
 					if (files != null) {


### PR DESCRIPTION
This allows a script to interrogate `isFileLimit()` reliably when a
changeset is serialized and then deserialized.

Without this change,
`src\main\resources\org\jenkinsci\plugins\p4\changes\P4ChangeSet\index.jelly`
does not correctly display the `...list truncated` string that it intends to.