### PR TITLE
JENKINS-64946 : Branch indexing occurring for every multibranch job

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/p4/DefaultEnvironment.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/DefaultEnvironment.java
@@ -236,7 +236,7 @@ abstract public class DefaultEnvironment {
 	}
 
 	protected boolean waitForBuild(WorkflowJob job, int buildNumber) throws InterruptedException {
-		return waitForBuild(job, buildNumber, 50, 200L);
+		return waitForBuild(job, buildNumber, 170, 200L);
 	}
 
 	protected boolean waitForBuild(WorkflowJob job, int buildNumber, final int retry, long delay) throws InterruptedException {


### PR DESCRIPTION
execution

WHAT

1. If multibranch project trigger a build for a branch then it should
build for head which is in the Observer and not for all heads that
matches the multibranch.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
