### PR TITLE
Change `status` to be a choice instead of a string

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/review/ReviewAction.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/review/ReviewAction.java
@@ -9,6 +9,7 @@ import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.Queue;
+import hudson.model.ChoiceParameterDefinition;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import jenkins.model.Jenkins;
@@ -148,7 +149,7 @@ public class ReviewAction<T extends Job<?, ?> & ParameterizedJob> implements Act
 		// Swarm parameters
 		swarm.add(new StringParameterDefinition(ReviewProp.SWARM_REVIEW.getProp(), null));
 		swarm.add(new StringParameterDefinition(ReviewProp.P4_CHANGE.getProp(), null));
-		swarm.add(new StringParameterDefinition(ReviewProp.SWARM_STATUS.getProp(), null));
+		swarm.add(new ChoiceParameterDefinition(ReviewProp.SWARM_STATUS.getProp(), {"shelved", "committed", "submitted"}, "The review status"));
 		swarm.add(new StringParameterDefinition(ReviewProp.SWARM_PASS.getProp(), null));
 		swarm.add(new StringParameterDefinition(ReviewProp.SWARM_FAIL.getProp(), null));
 


### PR DESCRIPTION
`status` is described as: 
>(Required field) The review status; must be one of the following strings: shelved, committed or submitted.
To me this sounds like a better match for a `ChoiceParameterDefinition`, as that can both enforce this parameter being required and limit the choices to the available choices.

I don't know if this change is as simple/trivial as it appears (or if this change would actually be desired), but I figured the easiest way to fund out would be to open a PR.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
