### PR TITLE
Allow option to not detect changelists for build, JENKINS-68516

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -1235,6 +1235,11 @@ public class ClientHelper extends ConnectionHelper {
 			return new ArrayList<P4Ref>();
 		}
 
+		// JENKINS-68516: skip changelist calculation if maxChanges=0.
+		if (getMaxChangeLimit() <= 0) {
+			return new ArrayList<P4Ref>();
+		}
+
 		String ws = "//" + iclient.getName() + "/...@" + from + "," + to;
 		List<P4Ref> list = listChanges(ws);
 		if (!from.isLabel()) {

--- a/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
@@ -586,7 +586,7 @@ public class ConnectionHelper extends SessionHelper implements AutoCloseable {
 		if (scm != null) {
 			max = scm.getMaxChanges();
 		}
-		max = (max > 0) ? max : PerforceScm.DEFAULT_CHANGE_LIMIT;
+		max = (max >= 0) ? max : PerforceScm.DEFAULT_CHANGE_LIMIT;
 		return max;
 	}
 


### PR DESCRIPTION
Setting the global option maxChanges (Maximum number of changes shown in a 
build) to 0 will skip collecting the changes for a build, no longer running the
"p4 changes ...@ last,current".  As a global option, this affects all builds.

