### PR TITLE
Do not quote the path when creating label

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/TaggingTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/TaggingTask.java
@@ -64,7 +64,7 @@ public class TaggingTask extends AbstractTask implements FileCallable<Boolean>,
 			for (IClientViewMapping entry : view) {
 				String left = entry.getLeft();
 				LabelMapping lblMap = new LabelMapping();
-				lblMap.setLeft("\""+left+"\"");
+				lblMap.setLeft(left);
 				lblMap.setType(entry.getType());  // Make sure type is carried forward
 				viewMapping.addEntry(lblMap);
 			}


### PR DESCRIPTION
P4Java handles a space in the path so quoting is not necessary.
Quoting the path for an EXCLUDE view line failed.
JENKINS-67631
