### PR TITLE
For ManualWorkspace views from a file, construct RHS if missing.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/p4/client/WorkspaceSpecTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/WorkspaceSpecTest.java
@@ -1,6 +1,9 @@
 package org.jenkinsci.plugins.p4.client;
 
 import com.perforce.p4java.client.IClient;
+import com.perforce.p4java.impl.generic.client.ClientView;
+import com.perforce.p4java.server.IOptionsServer;
+import com.perforce.p4java.server.ServerFactory;
 import hudson.EnvVars;
 import hudson.model.Cause;
 import hudson.model.FreeStyleBuild;
@@ -20,6 +23,10 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -98,4 +105,36 @@ public class WorkspaceSpecTest extends DefaultEnvironment {
 		assertEquals("disable", iclient.getBackup());
 		p4.disconnect();
 	}
+
+	/**
+	 * test for https://issues.jenkins.io/browse/JENKINS-69491
+ 	 */
+	@Test
+	public void adjustViewLineTest() throws Exception {
+
+		String clientName = "CLIENT";
+		String view = "\n//depot/Jam/... //placeholder/...\n" +
+				"//depot/java/yo/...\n\n" +
+				"-//depot/java/stuff //otherStuff/java/stuff\n\n" +
+				"//products/no/where/rhs\n" ;
+		String expectedView = "//depot/Jam/... //CLIENT/...\n" +
+				"//depot/java/yo/... //CLIENT/java/yo/...\n" +
+				"-//depot/java/stuff //CLIENT/java/stuff\n" +
+				"//products/no/where/rhs //CLIENT/no/where/rhs" ;
+
+		WorkspaceSpec spec = new WorkspaceSpec(false, true, false, false, false, false, null, "LOCAL", view, null, null, null, false);
+		ManualWorkspaceImpl workspace = new ManualWorkspaceImpl("none", false, clientName, spec,false);
+
+		StringBuilder postView = new StringBuilder(300);
+		for (String line : view.split("\n\\s*")) {
+			if ( postView.length() > 0) {
+				postView.append("\n");
+			}
+			postView.append( workspace.adjustViewLine(line, clientName, true));
+
+		}
+		System.out.println(p4d.getRshPort());
+		assertEquals(expectedView, postView.toString());
+	}
+
 }


### PR DESCRIPTION
When retrieving a view spec from a file (@//depot/path/to/view.txt) or a ManualWorkspace View, rows may only contain a depot view (LHS). The client RHS will be created if missing.

If LHS is "//depot/path/to/project/..." we'll add the RHS of "//CLIENT/path/to/project/..." using the correct client name.

JENKINS-69491

Also code cleanup:  convert spaces to tabs, adjust import ordering.

