### PR TITLE
JENKINS-69808: Cleanup client after publish, if enabled

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/publish/PublishNotifierStep.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/publish/PublishNotifierStep.java
@@ -49,5 +49,7 @@ public class PublishNotifierStep extends PublishNotifier implements SimpleBuildS
 		getPublish().setExpandedDesc(desc);
 
 		buildWorkspace.act(task);
+
+		cleanupPerforceClient(run, buildWorkspace, listener);
 	}
 }


### PR DESCRIPTION
Ensure the perforce client is cleaned up after publishing when the cleanup attribute is set on the workspace.

This is to address https://issues.jenkins.io/browse/JENKINS-69808

Note: I'm not very familiar with the Jenkins code base, so a thorough review would be appreciated.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
