### PR TITLE
Fix for:  Unable to unshelve change: java.lang.IllegalStateException: Expected 1 instance of hudson.model.User$AllUsers but got 0

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/UnshelveTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/UnshelveTask.java
@@ -1,15 +1,11 @@
 package org.jenkinsci.plugins.p4.tasks;
 
-import com.perforce.p4java.core.IChangelistSummary;
 import hudson.AbortException;
 import hudson.FilePath.FileCallable;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import jenkins.security.Roles;
-import org.jenkinsci.plugins.p4.changes.P4ChangeEntry;
-import org.jenkinsci.plugins.p4.changes.P4ChangeSet;
-import org.jenkinsci.plugins.p4.changes.P4Ref;
 import org.jenkinsci.plugins.p4.client.ClientHelper;
 import org.jenkinsci.plugins.p4.tagging.TagAction;
 import org.jenkinsci.remoting.RoleChecker;
@@ -18,8 +14,6 @@ import org.jenkinsci.remoting.RoleSensitive;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Logger;
 
 public class UnshelveTask extends AbstractTask implements FileCallable<Boolean>, Serializable {
@@ -31,13 +25,11 @@ public class UnshelveTask extends AbstractTask implements FileCallable<Boolean>,
 	private final String resolve;
 	private final boolean tidy;
 	private long shelf;
-	private final transient TagAction tagAction;
 
 	public UnshelveTask(String credential, Run<?, ?> run, TaskListener listener, String resolve, boolean tidy) {
 		super(credential, run, listener);
 		this.resolve = resolve;
 		this.tidy = tidy;
-		tagAction = run.getAction(TagAction.class);
 	}
 
 	public void setShelf(long shelf) {
@@ -54,8 +46,6 @@ public class UnshelveTask extends AbstractTask implements FileCallable<Boolean>,
 
 			p4.unshelveFiles(shelf);
 
-			updateChangeLogFile(p4);
-
 			p4.resolveFiles(resolve);
 
 			if(tidy) {
@@ -70,22 +60,6 @@ public class UnshelveTask extends AbstractTask implements FileCallable<Boolean>,
 			throw new AbortException(err);
 		}
 		return true;
-	}
-
-	private void updateChangeLogFile(ClientHelper p4) throws Exception {
-		List<P4ChangeEntry> changes = new ArrayList<>();
-		changes.add(createP4ChangeEntry(p4, shelf));
-		for (P4Ref ref : tagAction.getRefChanges()) {
-			changes.add(createP4ChangeEntry(p4, ref.getChange()));
-		}
-		P4ChangeSet.store(tagAction.getChangelog(), changes);
-	}
-
-	private P4ChangeEntry createP4ChangeEntry(ClientHelper p4, long shelf) throws Exception {
-		P4ChangeEntry cl = new P4ChangeEntry();
-		IChangelistSummary changelistSummary = p4.getChange(shelf);
-		cl.setChange(p4, changelistSummary);
-		return cl;
 	}
 
 	@Override

--- a/src/test/java/org/jenkinsci/plugins/p4/scm/PerforceSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/scm/PerforceSCMSourceTest.java
@@ -985,9 +985,9 @@ public class PerforceSCMSourceTest extends DefaultEnvironment {
 				"            populate: autoClean(delete: true, replace: true),\n" +
 				"            source: depotSource('//depot/UnshelveChange/sync/...')\n" +
 				"          p4unshelve credential: '" + CREDENTIAL + "', resolve: 'at', shelf: '" + shelveId + "',\n" +
-				"            workspace: manualSpec(charset: 'none', name: 'jenkins-${NODE_NAME}-${JOB_NAME}-${EXECUTOR_NUMBER}-unshelve',\n" +
+				"            workspace: manualSpec(charset: 'none', name: 'jenkins-unshelve-issue-workspace',\n" +
 				"            spec: clientSpec(backup: true, clobber: true, line: 'LOCAL', type: 'WRITABLE',\n" +
-				"              view: '//depot/UnshelveChange/unshelve/... //jenkins-${NODE_NAME}-${JOB_NAME}-${EXECUTOR_NUMBER}-unshelve/unshelve/... '))\n" +
+				"              view: '//depot/UnshelveChange/unshelve/... //jenkins-unshelve-issue-workspace/unshelve/... '))\n" +
 				"        }\n" +
 				"      }\n" +
 				"    }\n" +


### PR DESCRIPTION
Unable to unshelve change: java.lang.IllegalStateException: Expected 1 instance of hudson.model.User$AllUsers but got 0
https://issues.jenkins.io/browse/JENKINS-69172

When unshelve task is executed on a slave node, then Jenkins.getInstance() can not be used, hence no user is found while updating the changelog.

The changelog will get updated once the build is successful.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
