### PR TITLE
Update Jenkins to 2.222.4 and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.1</version>
   </parent>
 
   <artifactId>p4</artifactId>
@@ -17,7 +17,7 @@
   <url>https://github.com/jenkinsci/p4-plugin</url>
 
   <properties>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -110,31 +110,31 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.2.1</version>
+      <version>2.6.1.1</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.4.1</version>
+      <version>2.6.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.14.1</version>
+      <version>1.18</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.19</version>
+      <version>1.24</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>command-launcher</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
     </dependency>
 
     <!-- Workflow dependencies (aggregator) -->
@@ -142,31 +142,31 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.20</version>
+      <version>622.vb_8e7c15b_c95a_</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-multibranch</artifactId>
-      <version>2.20</version>
+      <version>2.24</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.71</version>
+      <version>1118.vba21ca2e3286</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>2.11</version>
+      <version>2.13</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.33</version>
+      <version>1122.v7a_916f363c86</version>
     </dependency>
 
     <!-- Optional dependencies -->
@@ -181,7 +181,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.23</version>
+      <version>1.32.1</version>
       <optional>true</optional>
     </dependency>
 
@@ -190,7 +190,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
-      <version>1.3</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -211,7 +211,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-stage-step</artifactId>
-      <version>2.4</version>
+      <version>2.5</version>
       <scope>test</scope>
     </dependency>
 
@@ -228,7 +228,32 @@
       <version>3.8.0</version>
       <scope>test</scope>
     </dependency>
-
+	
+	<!-- Overriding versions from parent pom  -->
+	
+	<dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+	</dependency>
+	
+	<dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
+	</dependency>
+	
+	<dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>display-url-api</artifactId>
+      <version>2.3.4</version>
+	</dependency>
+	
+	<dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20190722</version>
+	</dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Trigger.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Trigger.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.p4.trigger;
 
 import hudson.Extension;
 import hudson.Util;
-import hudson.console.AnnotatedLargeText;
 import hudson.model.Action;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -14,7 +13,6 @@ import hudson.triggers.TriggerDescriptor;
 import hudson.util.StreamTaskListener;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.SCMTriggerItem;
-import org.apache.commons.jelly.XMLOutput;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.p4.PerforceScm;
 import org.jenkinsci.plugins.p4.client.ConnectionHelper;
@@ -24,7 +22,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.logging.Logger;
@@ -160,16 +157,6 @@ public class P4Trigger extends Trigger<Job<?, ?>> {
 			return Util.loadFile(getLogFile(job));
 		}
 
-		/**
-		 * Writes the annotated log to the given output.
-		 *
-		 * @param out XML output
-		 * @throws IOException pudh up stack
-		 */
-		public void writeLogTo(XMLOutput out) throws IOException {
-			new AnnotatedLargeText<P4TriggerAction>(getLogFile(job), Charset.defaultCharset(), true, this).writeHtmlTo(0,
-					out.asWriter());
-		}
 	}
 
 	@Override

--- a/src/test/java/org/jenkinsci/plugins/p4/client/JenkinsfileTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/JenkinsfileTest.java
@@ -445,8 +445,8 @@ public class JenkinsfileTest extends DefaultEnvironment {
 		assertEquals(3, job.getLastBuild().getNumber());
 
 		List<String> log = job.getLastBuild().getLog(1000);
-		assertTrue(log.contains("[first_branch] Found last change " + head + " on syncID jenkins-master-multiParallelSyncPoll-1"));
-		assertTrue(log.contains("[second_branch] Found last change 9 on syncID jenkins-master-multiParallelSyncPoll-2"));
+		assertTrue(log.contains("Found last change " + head + " on syncID jenkins-master-multiParallelSyncPoll-1"));
+		assertTrue(log.contains("Found last change 9 on syncID jenkins-master-multiParallelSyncPoll-2"));
 
 		// Test trigger, no change
 		trigger.poke(job, p4d.getRshPort());

--- a/src/test/java/org/jenkinsci/plugins/p4/client/WorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/WorkflowTest.java
@@ -17,7 +17,6 @@ import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -550,7 +549,6 @@ public class WorkflowTest extends DefaultEnvironment {
 				+ "      credential: '" + CREDENTIAL + "',\n"
 				+ "      populate: forceClean(\n"
 				+ "        have: true,\n"
-				+ "        revert: true,\n"
 				+ "        quiet: false\n"
 				+ "      ),\n"
 				+ "      workspace: manualSpec(\n"
@@ -638,8 +636,8 @@ public class WorkflowTest extends DefaultEnvironment {
 				+ "  }])\n"
 				+ "}", false));
 		WorkflowRun run = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
-		jenkins.assertLogContains("[BranchOne] Client_1", run);
-		jenkins.assertLogContains("[BranchTwo] Client_2", run);
+		jenkins.assertLogContains("Client_1", run);
+		jenkins.assertLogContains("Client_2", run);
 	}
 
 	@Test

--- a/src/test/java/org/jenkinsci/plugins/p4/client/WorkspaceSpecTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/WorkspaceSpecTest.java
@@ -1,9 +1,6 @@
 package org.jenkinsci.plugins.p4.client;
 
 import com.perforce.p4java.client.IClient;
-import com.perforce.p4java.impl.generic.client.ClientView;
-import com.perforce.p4java.server.IOptionsServer;
-import com.perforce.p4java.server.ServerFactory;
 import hudson.EnvVars;
 import hudson.model.Cause;
 import hudson.model.FreeStyleBuild;
@@ -12,8 +9,6 @@ import hudson.model.Result;
 import org.jenkinsci.plugins.p4.DefaultEnvironment;
 import org.jenkinsci.plugins.p4.PerforceScm;
 import org.jenkinsci.plugins.p4.SampleServerRule;
-import org.jenkinsci.plugins.p4.build.ExecutorHelper;
-import org.jenkinsci.plugins.p4.build.NodeHelper;
 import org.jenkinsci.plugins.p4.populate.AutoCleanImpl;
 import org.jenkinsci.plugins.p4.populate.Populate;
 import org.jenkinsci.plugins.p4.workspace.ManualWorkspaceImpl;
@@ -23,10 +18,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -67,7 +58,7 @@ public class WorkspaceSpecTest extends DefaultEnvironment {
 		assertEquals(Result.SUCCESS, build.getResult());
 
 		// Test changeView is applied and source is at change 10099
-		jenkins.assertLogContains("Change 10099 on 2002/01/21 by rmg@rmg:pdjam:chinacat 'This change is integration hist'", build);
+		jenkins.assertLogContains("Change 10099 on 2002/01/22 by rmg@rmg:pdjam:chinacat 'This change is integration hist'", build);
 	}
 
 	@Test
@@ -108,7 +99,7 @@ public class WorkspaceSpecTest extends DefaultEnvironment {
 
 	/**
 	 * test for https://issues.jenkins.io/browse/JENKINS-69491
- 	 */
+	 */
 	@Test
 	public void adjustViewLineTest() throws Exception {
 
@@ -116,21 +107,21 @@ public class WorkspaceSpecTest extends DefaultEnvironment {
 		String view = "\n//depot/Jam/... //placeholder/...\n" +
 				"//depot/java/yo/...\n\n" +
 				"-//depot/java/stuff //otherStuff/java/stuff\n\n" +
-				"//products/no/where/rhs\n" ;
+				"//products/no/where/rhs\n";
 		String expectedView = "//depot/Jam/... //CLIENT/...\n" +
 				"//depot/java/yo/... //CLIENT/java/yo/...\n" +
 				"-//depot/java/stuff //CLIENT/java/stuff\n" +
-				"//products/no/where/rhs //CLIENT/no/where/rhs" ;
+				"//products/no/where/rhs //CLIENT/no/where/rhs";
 
 		WorkspaceSpec spec = new WorkspaceSpec(false, true, false, false, false, false, null, "LOCAL", view, null, null, null, false);
-		ManualWorkspaceImpl workspace = new ManualWorkspaceImpl("none", false, clientName, spec,false);
+		ManualWorkspaceImpl workspace = new ManualWorkspaceImpl("none", false, clientName, spec, false);
 
 		StringBuilder postView = new StringBuilder(300);
 		for (String line : view.split("\n\\s*")) {
-			if ( postView.length() > 0) {
+			if (postView.length() > 0) {
 				postView.append("\n");
 			}
-			postView.append( workspace.adjustViewLine(line, clientName, true));
+			postView.append(workspace.adjustViewLine(line, clientName, true));
 
 		}
 		System.out.println(p4d.getRshPort());

--- a/src/test/java/org/jenkinsci/plugins/p4/credentials/PerforceCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/credentials/PerforceCredentialsTest.java
@@ -73,7 +73,7 @@ public class PerforceCredentialsTest extends DefaultEnvironment {
 		assertNull(list.get(0).getSsl());
 
 		String name = CredentialsNameProvider.name(credential);
-		assertEquals("user/****** (desc:passwd)", name);
+		assertEquals("desc:passwd", name);
 	}
 
 	@Test
@@ -148,7 +148,7 @@ public class PerforceCredentialsTest extends DefaultEnvironment {
 		assertEquals("12345", auth.getTicketValue());
 
 		String name = CredentialsNameProvider.name(credential);
-		assertEquals("user (desc:ticket)", name);
+		assertEquals("desc:ticket", name);
 	}
 
 	@Test


### PR DESCRIPTION
1. Update jenkins version to 2.222.4
2. P4Trigger changes due to spotbugs plugin. This is unused so spotbugs rule fails the
build.
3. Need to update test because of update in dependencies