### PR TITLE
When checking if a value is a counter, do not call "p4 counter" for integer values

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ConnectionHelper.java
@@ -168,6 +168,10 @@ public class ConnectionHelper extends SessionHelper implements AutoCloseable {
 		if (name.equals("now")) {
 			return false;
 		}
+		// JENKINS-70219 - numeric counters are illegal in p4d
+		if (name.matches("(\\d*)")) {
+			return false;
+		}
 		try {
 			CounterOptions opts = new CounterOptions();
 			String counter = getConnection().getCounter(name, opts);

--- a/src/test/java/org/jenkinsci/plugins/p4/SimpleTestServer.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/SimpleTestServer.java
@@ -60,6 +60,9 @@ public class SimpleTestServer {
 
 		return rsh;
 	}
+	public String getLogPath() {
+		return p4root + File.separator + "log";
+	}
 
 	public void upgrade() throws Exception {
 		exec(new String[] { "-xu" });


### PR DESCRIPTION
do not call "p4 counter <value>" when the value is an integer as the helix core server does not allow integer counters.

in isCounter() method, check for all digits early.  If all digits, return false. 

Fix for JENKINS-70219: server's errors.csv fills up when populate's "pin" is to changelist.

Added simple isCounter() test to check:
1)  a counter that exists
2)  a counter that does not exit
3)  that a numeric counter doesn't call p4d (JENKINS-70219)

### Testing done
