### PR TITLE
[JENKINS-69491] Implement support for "@/path/to/spec" for "poll view" in ManualWorkspaceImpl.java too

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/workspace/ManualWorkspaceImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/workspace/ManualWorkspaceImpl.java
@@ -190,7 +190,7 @@ public class ManualWorkspaceImpl extends Workspace implements Serializable {
 				printOpts.setNoHeaderLine(true);
 				InputStream ins = null;
 				try {
-					connection.getFileContents(file, printOpts);
+					ins = connection.getFileContents(file, printOpts);
 					specString = IOUtils.toString(ins, "UTF-8");
 				} finally {
 					if (ins != null) {

--- a/src/main/java/org/jenkinsci/plugins/p4/workspace/ManualWorkspaceImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/workspace/ManualWorkspaceImpl.java
@@ -179,10 +179,8 @@ public class ManualWorkspaceImpl extends Workspace implements Serializable {
 		String view = workspaceSpec.getChangeView();
 		if (view != null) {
 			String specString = getExpand().format(view, true);
-			boolean fromFile = false;
 			if (specString.startsWith("@")) {
 				// extract View from file:	JENKINS-69491.
-				fromFile = true;
 				logger.fine("P4: view from file=" + specString);
 				String specPathFull = specString.substring(1).trim();
 				List<IFileSpec> file = FileSpecBuilder.makeFileSpecList(specPathFull);

--- a/src/main/java/org/jenkinsci/plugins/p4/workspace/ManualWorkspaceImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/workspace/ManualWorkspaceImpl.java
@@ -172,12 +172,34 @@ public class ManualWorkspaceImpl extends Workspace implements Serializable {
 	}
 
 
-	private ArrayList<String> getChangeView(WorkspaceSpec workspaceSpec) {
+	private ArrayList<String> getChangeView(IOptionsServer connection, WorkspaceSpec workspaceSpec) throws Exception
+    {
 		ArrayList<String> changeView = new ArrayList<>();
 
 		String view = workspaceSpec.getChangeView();
 		if (view != null) {
 			String specString = getExpand().format(view, true);
+			boolean fromFile = false;
+			if (specString.startsWith("@")) {
+				// extract View from file:	JENKINS-69491.
+				fromFile = true;
+				logger.fine("P4: view from file=" + specString);
+				String specPathFull = specString.substring(1).trim();
+				List<IFileSpec> file = FileSpecBuilder.makeFileSpecList(specPathFull);
+				GetFileContentsOptions printOpts = new GetFileContentsOptions();
+				printOpts.setNoHeaderLine(true);
+				InputStream ins = null;
+				try {
+					connection.getFileContents(file, printOpts);
+					specString = IOUtils.toString(ins, "UTF-8");
+				} finally {
+					if (ins != null) {
+						ins.close();
+					}
+				}
+				specString = getExpand().format(specString, true);
+			}
+
 			for (String line : specString.split("\\n")) {
 				changeView.add(line);
 			}
@@ -238,7 +260,7 @@ public class ManualWorkspaceImpl extends Workspace implements Serializable {
 
 		// Set Change view
 		if (connection.getServerVersionNumber() >= 20172) {
-			iclient.setChangeView(getChangeView(getSpec()));
+			iclient.setChangeView(getChangeView(connection, getSpec()));
 		}
 
 		// Allow change between GRAPH and WRITEABLE


### PR DESCRIPTION
Also support "@" in the view for polling.
This is a continuation of what was implemented for JENKINS-69491, but the polling view was forgotten.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
