### PR TITLE
Check if parent job is MatrixConfiguration instead of MatrixProject

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/PerforceScm.java
@@ -607,7 +607,7 @@ public class PerforceScm extends SCM {
 				success = true;
 			}
 		} else {
-			if (job instanceof MatrixProject) {
+			if (job instanceof MatrixProject || job instanceof MatrixConfiguration) {
 				if (parentChange != null) {
 					log.println("Using parent change: " + parentChange);
 					task.setBuildChange(parentChange);


### PR DESCRIPTION
Update PerforceScm.java - 
Check if parent job is MatrixConfiguration instead of MatrixProject when doing a matrix build: checkouts should be the same for each run of the matrix build see also https://issues.jenkins.io/projects/JENKINS/issues/JENKINS-71364

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
