### PR TITLE
JENKINS-72098: Cant sync global libraries on Windows

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -496,9 +496,14 @@ public class ClientHelper extends ConnectionHelper {
 		} catch (FileNotFoundException ignored) {
 			// ignore
 		} catch (IOException alt) {
+			Path pathToDelete = Paths.get(root);
+			if (!Files.exists(pathToDelete)) {
+				return;
+			}
+
 			log("Unable to delete, trying alternative method... " + alt.getLocalizedMessage());
 
-			List<Path> pathsToDelete = Files.walk(Paths.get(root))
+			List<Path> pathsToDelete = Files.walk(pathToDelete)
 					.sorted(Comparator.reverseOrder())
 					.collect(Collectors.toList());
 			boolean success = true;


### PR DESCRIPTION
After the Pipeline Groovy Library was modified to delete the temporary directory itself
(https://github.com/jenkinsci/pipeline-groovy-lib-plugin/commit/76ad53e052aa7b9a7d0101b23e83a8ed5ab43feb)
global libraries failed with Perforce modern SCM
[JENKINS-72098](https://issues.jenkins.io/browse/JENKINS-72098)
[JENKINS-71763](https://issues.jenkins.io/browse/JENKINS-71763)

The issue arises because '**FileUtils.forceDelete**' throws a '**java.io.IOException: DOS or POSIX file operations not available for**'
when the file does not exist on Windows, even though the documentation indicates it should throw a '**FileNotFoundException**'
https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FileUtils.html#forceDelete(java.io.File)

I have added a check for path existence after '**FileUtils.forceDelete**' fails.
If the path does not exist, it simply returns.


### Testing done
Before
![image](https://github.com/jenkinsci/p4-plugin/assets/37609477/171bff18-86af-4a75-991a-787011c6c10c)

After
![image](https://github.com/jenkinsci/p4-plugin/assets/37609477/86618a94-1383-4d54-8801-961a26a68dc2)

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
