### PR TITLE
getClientHead without range

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -1167,12 +1167,15 @@ public class ClientHelper extends ConnectionHelper {
 	 * @throws Exception push up stack
 	 */
 	public long getClientHead() throws Exception {
+		// try to find last change
+		long head = getClientHead(null, null);
+		if (head != 0L) {
+			return head;
+		}
+
 		// get last change in server, may return shelved CLs
 		String latestChange = getConnection().getCounter("change");
-		long latest = Long.parseLong(latestChange);
-		P4Ref to = new P4ChangeRef(latest);
-		long head = getClientHead(null, to);
-		return (head == 0L) ? latest : head;
+		return Long.parseLong(latestChange);
 	}
 
 	public List<IChangelistSummary> getPendingChangelists(boolean includeLongDescription, String clientName) throws Exception {


### PR DESCRIPTION
Our Perforce server has been operational since July 2, 2013, and the current changelist number is 1524832.

Normally, using changes -m is efficient for both users and build machines due to our optimization settings.
(For more details, see [Server performance related to 'p4 changes'
](https://portal.perforce.com/s/article/1188)).

However, retrieving changes for a specific client and revision is significantly slower
(changes -m1 //clientname/...@rev).
This slowdown affects the plugin's ability to determine the latest changelist number for clients.

I believe that setting a revision range for changes is not essential, and omitting it could enhance performance.
According to the documentation, optimizations are most effective when not restricted by revision specifications.

I have already implemented this change in our Jenkins setup, and it has shown positive results.


**Before**
![image](https://github.com/jenkinsci/p4-plugin/assets/37609477/a1756ead-2abc-42dc-b209-334b7e041cc7)


**After**
![image](https://github.com/jenkinsci/p4-plugin/assets/37609477/101509da-3533-41cc-af70-b8deb5d4fae0)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
