### PR TITLE
Add Validate#checkCatch overload to set quiet flag

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/Validate.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/Validate.java
@@ -37,17 +37,38 @@ public class Validate {
 	 * Only return boolean; false is returned for an exception.
 	 *
 	 * @param fileSpecs List of Perforce file specs
+	 * @param quiet    Flag controlling if unknown messages are logged
 	 * @param ignore    Parameter list of messages to ignore (case insensitive)
 	 * @return true if no errors or exceptions
 	 */
-	public boolean checkCatch(List<IFileSpec> fileSpecs, String... ignore) {
+	public boolean checkCatch(List<IFileSpec> fileSpecs, boolean quiet, String... ignore) {
 		try {
-			return check(fileSpecs, true, ignore);
+			return check(fileSpecs, quiet, ignore);
 		} catch (Exception e) {
 			return false;
 		}
 	}
 
+	/**
+	 * Only return boolean; false is returned for an exception.
+	 *
+	 * @param fileSpecs List of Perforce file specs
+	 * @param ignore    Parameter list of messages to ignore (case insensitive)
+	 * @return true if no errors or exceptions
+	 */
+	public boolean checkCatch(List<IFileSpec> fileSpecs, String... ignore) {
+		return checkCatch(fileSpecs, true, ignore);
+	}
+
+	/**
+	 * Look for a message in the returned FileSpec from operation.
+	 *
+	 * @param fileSpecs List of Perforce file specs
+	 * @param quiet    Flag controlling if unknown messages are logged
+	 * @param ignore    Parameter list of messages to ignore (case insensitive)
+	 * @return true if no errors.
+	 * @throws Exception push up stack
+	 */
 	public boolean check(List<IFileSpec> fileSpecs, boolean quiet, String... ignore) throws Exception {
 		boolean success = true;
 		boolean abort = false;


### PR DESCRIPTION
Added a new overload for [Validate#checkCatch](https://github.com/jenkinsci/p4-plugin/blob/2922a8d230537f535b5d1fbf3c7334f18438fa7f/src/main/java/org/jenkinsci/plugins/p4/client/Validate.java#L43) that exposes the `quiet` flag to the user.

Implementation for [JENKINS-72884](https://issues.jenkins.io/browse/JENKINS-72884)

### Testing done
N/A

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
