### PR TITLE
client/ClientHelper.java: fix check for p4 error message when there are multiple files to reconcile

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -793,7 +793,7 @@ public class ClientHelper extends ConnectionHelper {
 		}
 
 		List<IFileSpec> status = iclient.reconcileFiles(files, statusOpts);
-		getValidate().check(status, "- no file(s) to reconcile", "instead of", "empty, assuming text", "also opened by");
+		getValidate().check(status, "No file(s) to reconcile", "- no file(s) to reconcile", "instead of", "empty, assuming text", "also opened by");
 	}
 
 	public String publishChange(Publish publish) throws Exception {


### PR DESCRIPTION
Original patch by Akos Bannerth

Closes: https://issues.jenkins.io/browse/JENKINS-72335

When using p4publish with multiple paths listed in the `paths` argument, and the workspace doesn't contain any changes compared to the depot, publish will fail with
```
Unable to publish workspace: hudson.AbortException: P4JAVA: Error(s):
No file(s) to reconcile.
```

This seems to be a result of a check in [ClientHelper.java](https://github.com/jenkinsci/p4-plugin/blob/master/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java#L796)
```
getValidate().check(status, "- no file(s) to reconcile", "instead of", "empty, assuming text", "also opened by");
```

which apparently should ignore the p4java status "- no file(s) to reconcile" but when reconciling with multiple paths, the message is "No file(s) to reconcile." - this can be easily tested from the command line:
```
> p4 rec foo/...
foo/... - no file(s) to reconcile.
> p4 rec foo/... bar/...
No file(s) to reconcile.
```

The attached patch changes the ignore string so that it's recognized in both cases, as the check uses StringUtils.containsIgnoreCase(msg, istring) to compare the message with it.

### Testing done

Built plugin and tested change on a staging server.


```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```