### PR TITLE
Replacing "+" to "%2B" before URLDecoding to retain "+" in client wor…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -68,6 +68,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -489,7 +490,8 @@ public class ClientHelper extends ConnectionHelper {
 		syncFiles(revisions, clean);
 
 		// remove all files from workspace
-		String root = URLDecoder.decode(iclient.getRoot(), "UTF-8");
+		String encodedRoot = iclient.getRoot().replace("+", "%2B");
+		String root = URLDecoder.decode(encodedRoot, StandardCharsets.UTF_8);
 		log("... rm -rf " + root);
 		log("");
 		silentlyForceDelete(root);


### PR DESCRIPTION
URLDecoder replaces a '+” to “ “. This is expected behaviour. But if a client workspace have a + sign it will also get replaced and which raises file not found error. Replacing "+" to "%2B" before URLDecoding to retain "+" in client workspace name.