### PR TITLE
Use depot path syntax over local path syntax for syncing

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/client/ClientHelper.java
@@ -332,8 +332,9 @@ public class ClientHelper extends ConnectionHelper {
 		// Sync changes/labels
 		if (buildChange instanceof P4ChangeRef || buildChange instanceof P4LabelRef) {
 			// build file revision spec
-			String path = iclient.getRoot() + "/...";
-			String revisions = path + "@" + buildChange;
+			String localPath = iclient.getRoot() + "/...";
+			String depotPath = where(localPath);
+			String revisions = depotPath + "@" + buildChange;
 
 			// Sync files
 			if (populate instanceof CheckOnlyImpl) {
@@ -460,22 +461,23 @@ public class ClientHelper extends ConnectionHelper {
 	public void tidyWorkspace(Populate populate) throws Exception {
 		// relies on workspace view for scope.
 		log("");
-		String path = iclient.getRoot() + "/...";
+		String localPath = iclient.getRoot() + "/...";
+		String depotPath = where(localPath);
 
 		if (populate instanceof AutoCleanImpl) {
-			tidyAutoCleanImpl(path, populate);
+			tidyAutoCleanImpl(depotPath, populate);
 		}
 
 		if (populate instanceof ForceCleanImpl) {
-			tidyForceSyncImpl(path, populate);
+			tidyForceSyncImpl(depotPath, populate);
 		}
 
 		if (populate instanceof GraphHybridImpl) {
-			tidyForceSyncImpl(path, populate);
+			tidyForceSyncImpl(depotPath, populate);
 		}
 
 		if (populate instanceof SyncOnlyImpl) {
-			tidySyncOnlyImpl(path, populate);
+			tidySyncOnlyImpl(depotPath, populate);
 		}
 	}
 
@@ -492,7 +494,7 @@ public class ClientHelper extends ConnectionHelper {
 		tidyPending(path);
 
 		// remove all versioned files (clean have list)
-		String revisions = iclient.getRoot() + "/...#0";
+		String revisions = path + "#0";
 
 		// Only use quiet populate option to insure a clean sync
 		boolean quiet = populate.isQuiet();


### PR DESCRIPTION
Fix for https://issues.jenkins.io/browse/JENKINS-73888. Use depot path syntax instead of local path syntax when syncing. Use [`WhereDelegator#where`](https://www.perforce.com/manuals/p4java-javadoc/com/perforce/p4java/client/delegator/IWhereDelegator.html#where(java.util.List)) to translate local path to depot path.

### Testing done

Ran existing unit tests to ensure there were no knock-ons from the change.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
