### PR TITLE
Replace hardcoded value with StandardCharset

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Hook.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Hook.java
@@ -20,7 +20,7 @@ import org.kohsuke.stapler.verb.POST;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URLDecoder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -61,7 +61,7 @@ public class P4Hook implements UnprotectedRootAction {
 			return;
 		}
 
-		String body = IOUtils.toString(req.getInputStream(), Charset.forName("UTF-8"));
+		String body = IOUtils.toString(req.getInputStream(), StandardCharsets.UTF_8);
 		if (body.startsWith("payload=")) {
 			body = body.substring(8);
 		}
@@ -78,10 +78,10 @@ public class P4Hook implements UnprotectedRootAction {
 
 		checkPermission(Item.BUILD);
 
-		String body = IOUtils.toString(req.getInputStream(), Charset.forName("UTF-8"));
+		String body = IOUtils.toString(req.getInputStream(), StandardCharsets.UTF_8);
 		String contentType = req.getContentType();
 		if (contentType != null && contentType.startsWith("application/json")) {
-			body = URLDecoder.decode(body, "UTF-8");
+			body = URLDecoder.decode(body, StandardCharsets.UTF_8);
 		}
 		if (body.startsWith("payload=")) {
 			body = body.substring(8);

--- a/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Hook.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/trigger/P4Hook.java
@@ -98,18 +98,14 @@ public class P4Hook implements UnprotectedRootAction {
 			}
 
 			// Use an executor to prevent blocking the trigger during polling
-			executorService.submit(new Runnable() {
-
-				@Override
-				public void run() {
-					try {
-						probeJobs(port, jobs);
-					} catch (IOException e) {
-						LOGGER.severe("Error on Polling Thread.");
-						e.printStackTrace();
-					}
-				}
-			});
+			executorService.submit(() -> {
+                try {
+                    probeJobs(port, jobs);
+                } catch (IOException e) {
+                    LOGGER.severe("Error on Polling Thread : " + e.getMessage());
+                    e.printStackTrace();
+                }
+            });
 		}
 	}
 


### PR DESCRIPTION
- [x] Replaced hardcoded values like "UTF-8" with StandardCharsets.UTF_8 to follow  best practices. This ensures better readability, avoids potential typos, and uses predefined constants for standard character sets.
- [x] Use lambda function for better readability
- [x] Log error msg in catch block 

Let me know if this needs more work or any changes 😁