### PR TITLE
P4_CHANGELIST documentation Upgraded

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/PerforceScm/buildEnv.properties
@@ -1,4 +1,4 @@
-P4_CHANGELIST.blurb=The last Perforce changelist number included in the populated workspace.
+P4_CHANGELIST.blurb=The last Perforce changelist number included in the populated workspace, or the latest changelist number across the Perforce server if no changelist is found in the workspace.
 P4_CLIENT.blurb=The Perforce client workspace name.
 P4_PORT.blurb=The Perforce server connection port (e.g. perforce:1666).
 P4_ROOT.blurb=The Perforce client workspace root path.

--- a/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
+++ b/src/main/resources/org/jenkinsci/plugins/p4/build/P4EnvironmentContributor/buildEnv.properties
@@ -1,4 +1,4 @@
-P4_CHANGELIST.blurb=The last Perforce changelist number included in the populated workspace.
+P4_CHANGELIST.blurb=The last Perforce changelist number included in the populated workspace, or the latest changelist number across the Perforce server if no changelist is found in the workspace.
 P4_CLIENT.blurb=The Perforce client workspace name.
 P4_PORT.blurb=The Perforce server connection port (e.g. perforce:1666).
 P4_ROOT.blurb=The Perforce client workspace root path.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-73075

JENKINS-73075 : P4_CHANGELIST is not documented when there are no changelists in workspace

Description Of changes -> I changed the documentation of **P4_CHANGELIST**  from `The last Perforce changelist number included in the populated workspace.` to `The last Perforce changelist number included in the populated workspace, or the latest changelist number across the Perforce server if no changelist is found in the workspace.` as discussed in the issue discussion. 
This documentation also helps the users with understanding the content of P4_CHANGELIST when a workspace is not populated.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
