### PR TITLE
Modern SCM Helix Libraries directories never reused

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/scm/GlobalLibraryScmSource.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/scm/GlobalLibraryScmSource.java
@@ -103,8 +103,7 @@ public class GlobalLibraryScmSource extends AbstractP4ScmSource {
 			throw new IllegalArgumentException("missing path");
 		}
 
-		UUID uuid = UUID.randomUUID();
-		setFormat("jenkins-lib-" + uuid);
+		setFormat("jenkins-lib-${NODE_NAME}-${JOB_NAME}-${BUILD_NUMBER}-${EXECUTOR_NUMBER}");
 
 		// patch for older configuration version when '/...' was not required.
 		String depotView = path.getPath();


### PR DESCRIPTION
Helix Libraries loaded with Modern SCM should not create a new directory for each build.

Fix For: JENKINS-73323

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
