### PR TITLE
Fix retry backoff: use t*t instead of bitwise XOR t^2

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/AbstractTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/AbstractTask.java
@@ -225,7 +225,7 @@ public abstract class AbstractTask implements Serializable {
 
 				// back off n^2 seconds, before retry
 				try {
-					TimeUnit.SECONDS.sleep(t ^ 2);
+					TimeUnit.SECONDS.sleep((long) t * t);
 				} catch (InterruptedException e2) {
 					Thread.currentThread().interrupt();
 				}


### PR DESCRIPTION
Tiny one-liner. ^ is XOR in Java, not power, so

sleep(t ^ 2)

doesn't do what the comment ("back off n^2 seconds") promises. Actual delays:

t=1: 3s, t=2: 0s, t=3: 1s, t=4: 6s, t=5: 7s

Attempt 2 takes no break at all. Changed to (long) t * t.
