### PR TITLE
Fix Flaky PollingTest

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/p4/client/PollingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/PollingTest.java
@@ -720,8 +720,9 @@ class PollingTest extends DefaultEnvironment {
 				+ "  }\n"
 				+ "}", false));
 
-		// enable SCM polling (even though we poll programmatically)
-		SCMTrigger cron = new SCMTrigger("* * * * *");
+		// enable SCM polling (even though we poll programmatically); use a
+		// daily spec so the live scheduler never races an extra poll during the test
+		SCMTrigger cron = new SCMTrigger("0 0 * * *");
 		job.addTrigger(cron);
 
 		// disable concurrent builds


### PR DESCRIPTION
## Problem

`PollingTest.testPollingLatestChangeFilter` intermittently fails on the slower Windows integration agent:

```
Poll and trigger Build #2 ==> expected: <2> but was: <3>
```

The test registers a live `SCMTrigger("* * * * *")` (fires every minute) while also polling programmatically via `cron.run()`. It asserts that exactly one build (#2) is triggered. On a slow agent, Jenkins' own scheduled poll can fire on a wall-clock minute boundary *after* `file.002`/`file.003` are submitted, detect those changes, and trigger a spurious Build #3 — failing the strict `assertEquals(2, ...)`.

## Fix

Change the trigger spec to `"0 0 * * *"` (daily at midnight) so the live scheduler never fires during the test, matching the pattern already used by sibling tests in the same file (lines ~794/865/940). The explicit `cron.run()` still performs a genuine poll and triggers Build #2 — that path is independent of the schedule string — so what the test verifies is unchanged.

## Verification

Clean build with `p4d`, test passes (46.87 s). Log confirms the intended behavior:

```
SCM changes detected in PollingLatestChangeFilter. Triggering  #2
```

Test-only change; no production code touched.