### PR TITLE
Add support for wildcards in polling filter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/p4/tasks/PollTask.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/tasks/PollTask.java
@@ -187,13 +187,13 @@ public class PollTask extends AbstractTask implements FileCallable<List<P4Ref>>,
 					String p = s.getDepotPathString();
 					for (String maskPath : maskPaths) {
 						maskPath = maskPath.trim(); // remove leading/trailing spaces
-						if (p.startsWith(maskPath)) {
+						if (isMatch(p, maskPath)) {
 							isFileInViewMask = true;
 						}
 
 						if (maskPath.startsWith("-")) {
 							String excludedMaskPath = maskPath.substring(maskPath.indexOf("-") + 1);
-							if (p.startsWith(excludedMaskPath)) {
+							if (isMatch(p, excludedMaskPath)) {
 								isFileInViewMask = false;
 							}
 						}
@@ -236,6 +236,21 @@ public class PollTask extends AbstractTask implements FileCallable<List<P4Ref>>,
 
 		}
 		return false;
+	}
+
+	/**
+	 * Check if path and path mask match
+	 * @return boolean
+	 */
+	private boolean isMatch(String path, String mask) {
+		mask = mask
+				.replace("*", ".*")
+				.replace("/.../", "/.+/");
+
+		Pattern p = Pattern.compile('^' + mask + ".*");
+		Matcher m = p.matcher(path);
+
+		return m.matches();
 	}
 
 	public void checkRoles(RoleChecker checker) throws SecurityException {

--- a/src/main/resources/org/jenkinsci/plugins/p4/filters/FilterViewMaskImpl/help-viewMask.html
+++ b/src/main/resources/org/jenkinsci/plugins/p4/filters/FilterViewMaskImpl/help-viewMask.html
@@ -9,6 +9,8 @@
 		<br/>
 		<code style="margin-left: 60.0px;">-//depot/main/tests/001</code>
 		<br/>
+		<code style="margin-left: 60.0px;">-//.../*.txt</code>
+		<br />
 	</p>
 	<p style="margin-left: 60.0px;">
 		<strong>Case A</strong> (change will not be filtered, as index.xml is 
@@ -50,6 +52,17 @@
 		<li style="margin-left: 90.0px;"><code>//depot/main/src/build.xml</code>
 		</li>
 		<li style="margin-left: 90.0px;"><code>//depot/main/tests/001/test.xml</code>
+		</li>
+	</ul>
+	<p style="margin-left: 60.0px;">
+		<strong>Case E</strong> (change will be filtered, as *.txt files
+		are excluded with view mask):
+	</p>
+	<p style="margin-left: 90.0px;">Files:</p>
+	<ul>
+		<li style="margin-left: 90.0px;"><code>//depot/main/tests/readme.txt</code>
+		</li>
+		<li style="margin-left: 90.0px;"><code>//depot/main/tests/001/readme.txt</code>
 		</li>
 	</ul>
 </div>

--- a/src/test/java/org/jenkinsci/plugins/p4/client/PollingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/PollingTest.java
@@ -374,6 +374,52 @@ class PollingTest extends DefaultEnvironment {
 	}
 
 	@Test
+	void testPollingMaskExclWildcard() throws Exception {
+
+		String client = "PollingMaskExcl.ws";
+		String view = "//depot/... //" + client + "/...";
+		WorkspaceSpec spec = new WorkspaceSpec(view, null);
+
+		FreeStyleProject project = jenkins.createFreeStyleProject("PollingMaskExclWildcard");
+		ManualWorkspaceImpl workspace = new ManualWorkspaceImpl("none", false, client, spec, false);
+
+		Populate populate = new AutoCleanImpl();
+		List<Filter> filter = new ArrayList<Filter>();
+
+		// Filter changes outside of //depot/Data and and all *-1.dat files
+		StringBuilder sb = new StringBuilder();
+		sb.append("//depot/Data");
+		sb.append("\n");
+		sb.append("-//.../*-1.dat");
+
+		FilterViewMaskImpl mask = new FilterViewMaskImpl(sb.toString());
+		filter.add(mask);
+		PerforceScm scm = new PerforceScm(CREDENTIAL, workspace, filter, populate, null);
+		project.setScm(scm);
+		project.save();
+
+		// Build at change 1
+		List<ParameterValue> list = new ArrayList<ParameterValue>();
+		list.add(new StringParameterValue(ReviewProp.SWARM_STATUS.toString(), "submitted"));
+		list.add(new StringParameterValue(ReviewProp.P4_CHANGE.toString(), "1"));
+		Action actions = new SafeParametersAction(new ArrayList<ParameterValue>(), list);
+
+		FreeStyleBuild build;
+		Cause.UserIdCause cause = new Cause.UserIdCause();
+		build = project.scheduleBuild2(0, cause, actions).get();
+		assertEquals(Result.SUCCESS, build.getResult());
+
+		// Poll for changes incrementally
+		Logger polling = Logger.getLogger("Polling");
+		TestHandler pollHandler = new TestHandler();
+		polling.addHandler(pollHandler);
+		LogTaskListener listener = new LogTaskListener(polling, Level.INFO);
+		project.poll(listener);
+		assertThat(pollHandler.getLogBuffer(), containsString("found change: 17"));
+		assertThat(pollHandler.getLogBuffer(), not(containsString("found change: 18")));
+	}
+
+	@Test
 	void testPatternList() throws Exception {
 		String client = "PatternList.ws";
 		String view = "//depot/... //" + client + "/...";


### PR DESCRIPTION
This is implementation of JENKINS-66195, add support of defining view filters as wildcards, eg:

//depot/path
-//.../*.txt

It would exclude changelist consisting of only one text file.

### Testing done


### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed